### PR TITLE
UI: legibilidad + imágenes mobile (CSS-only)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -60,6 +60,12 @@
       overflow-x:hidden;
     }
     a{color:var(--link)}
+    a:focus-visible{
+      outline:2px solid rgba(96,165,250,.95);
+      outline-offset:2px;
+      border-radius:8px;
+    }
+    img{max-width:100%;height:auto;display:block}
     .nav a{color:var(--text);text-decoration:none;}
     .wrap{max-width:1160px;margin:0 auto;padding:0 18px}
     .nav{
@@ -118,7 +124,8 @@
     }
     .btn:active{transform: translateY(0);}
     .btn:focus-visible{
-      outline:none;
+      outline:2px solid rgba(248,250,252,.95);
+      outline-offset:2px;
       box-shadow:0 0 0 4px rgba(37,99,235,.18);
     }
     .btn:disabled,
@@ -132,7 +139,11 @@
       box-shadow: 0 14px 32px rgba(249,115,22,.18);
     }
     .btnPrimary:hover{background: var(--cta-hover);border-color: var(--cta-hover);}
-    .btnPrimary:focus-visible{box-shadow:0 0 0 4px rgba(249,115,22,.22);}
+    .btnPrimary:focus-visible{
+      outline:2px solid rgba(255,255,255,.95);
+      outline-offset:2px;
+      box-shadow:0 0 0 4px rgba(249,115,22,.22);
+    }
 
     .btnSecondary{
       background: #25D366;
@@ -141,7 +152,11 @@
       box-shadow: 0 10px 24px rgba(37,211,102,.16);
     }
     .btnSecondary:hover{background: #1EBE5D;border-color:#1EBE5D;}
-    .btnSecondary:focus-visible{box-shadow:0 0 0 4px rgba(37,211,102,.22);}
+    .btnSecondary:focus-visible{
+      outline:2px solid rgba(255,255,255,.95);
+      outline-offset:2px;
+      box-shadow:0 0 0 4px rgba(37,211,102,.22);
+    }
 
     .btnGhost{
       background: var(--surface);
@@ -235,11 +250,47 @@
       line-height:1.45;
     }
     @media (max-width: 640px){
-      body{font-size:15px;line-height:1.6;}
-      .sub{line-height:1.65;font-size:15.5px;}
-      .sectionTitle p{line-height:1.6;font-size:14px;}
-      .bullet{line-height:1.45;font-size:13.5px;}
-      .fine{line-height:1.55;font-size:12.5px;}
+      body{font-size:16px;line-height:1.65;}
+      .sub{line-height:1.65;font-size:16.5px;}
+      .sectionTitle p{line-height:1.6;font-size:15.5px;}
+      .bullet{line-height:1.5;font-size:15px;}
+      .fine{line-height:1.6;font-size:13.5px;}
+    }
+    @media (max-width: 430px){
+      body{font-size:16.5px;line-height:1.7;}
+      .btn,
+      .btnSm,
+      .btnXL,
+      .trustActionsRow .btn{
+        font-size:18px;
+        line-height:1.3;
+      }
+      .btn{padding:14px 16px;}
+      .btnSm{padding:12px 14px;}
+      .sub{font-size:17px;line-height:1.7;}
+      .sectionTitle p,
+      .list,
+      .checkBullets,
+      .trustText,
+      .resultText,
+      .hint,
+      .videoShell .hint,
+      .videoShell .hint p,
+      .gText,
+      .gList{
+        font-size:16px;
+        line-height:1.65;
+      }
+      .bullet,
+      .callout,
+      .subcopyLead,
+      .fine,
+      .trustPoints li,
+      .check span{
+        font-size:15.5px;
+        line-height:1.6;
+      }
+      .pill{font-size:13px;line-height:1.3;}
     }
 
     /* Video card */
@@ -452,6 +503,7 @@
       display:flex;
       align-items:center;
       justify-content:center;
+      overflow:hidden;
       padding:18px;
     }
     .productMedia img{
@@ -470,6 +522,7 @@
       display:flex;
       align-items:center;
       justify-content:center;
+      overflow:hidden;
       padding:14px;
     }
     .systemMedia img{
@@ -492,6 +545,8 @@
       display:block;
       width:100%;
       height:auto;
+      object-fit:contain;
+      object-position:center;
       aspect-ratio: 1670 / 1206;
     }
 
@@ -598,7 +653,8 @@
       border: 1px solid var(--border);
       background: var(--surface);
       color: var(--text);
-      outline:none;
+      outline:2px solid transparent;
+      outline-offset:2px;
     }
     input:focus{border-color: var(--cta); box-shadow: 0 0 0 4px rgba(22,163,74,.14)}
     .formActions{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px}
@@ -783,11 +839,13 @@
       background:var(--surface);
       border-bottom:1px solid var(--border);
       padding:12px;
+      overflow:hidden;
     }
     .trustMedia img{
       width:100%;
       height:220px;
       object-fit:contain;
+      object-position:center;
       display:block;
       background:var(--surface);
       border-radius:12px;


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad en pantallas móviles (botones, tabs, párrafos) sin tocar la arquitectura, el orden de secciones ni el copy. 
- Evitar que imágenes desborden o se estiren en móviles y asegurar que mantengan proporción y centrado. 
- Incrementar la visibilidad y accesibilidad de `:focus-visible` para controles interactivos. 
- Aplicar cambios únicamente vía CSS en el archivo de landing para cubrir el rango móvil (320–430px) sin romper desktop.

### Description
- Añadido un baseline de imágenes `img{max-width:100%;height:auto;display:block}` y reglas `object-fit:contain`/`object-position:center` en banners y tiles, además de `overflow:hidden` en contenedores relevantes. 
- Ajustados tamaños tipográficos y `line-height` en media queries móviles, y añadidos ajustes específicos para `max-width:430px` para botones (`.btn`, `.btnSm`, `.btnXL`) y texto de párrafos/tabs. 
- Mejoradas las pautas de foco accesible: `:focus-visible` para `.btn`, `.btnPrimary`, `.btnSecondary` y `a` usan outlines visibles y `outline-offset`, y `input` incorpora outline manejable. 
- Todos los cambios se realizaron solo en `landing_venta.html` dentro de la hoja `<style>` embebida (CSS-only), sin tocar API, data ni estructura HTML significativa.

### Testing
- Levanté un servidor local y tomé una captura de pantalla móvil con Playwright (`width:390;height:844`) para validar visualmente el render móvil, y la operación finalizó correctamente. 
- Verifiqué que el archivo modificado fue únicamente `landing_venta.html` y que no se añadieron scripts ni credenciales. 
- No se ejecutaron pruebas automáticas de integración; los cambios son solo CSS dentro del HTML y el chequeo fue visual/local. 
- Resultado: pruebas locales (servido + screenshot) exitosas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69534304b2dc8325a709cb820d1b1b50)