### PR TITLE
UI: tipografía 40+ + contraste (lectura fácil)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -52,6 +52,8 @@
       margin:0;
       font-family: var(--font-base);
       color: var(--text);
+      font-size:17px;
+      line-height:1.6;
       background-color: var(--bg);
       background:
         radial-gradient(1200px 620px at 18% 12%, rgba(249,115,22,.14), transparent 55%),
@@ -210,8 +212,8 @@
     .sub{
       margin:0 0 16px;
       color: var(--muted);
-      font-size: 16px;
-      line-height:1.55;
+      font-size: 17px;
+      line-height:1.6;
       max-width: 62ch;
     }
     .kicker{
@@ -239,25 +241,25 @@
       border:1px solid var(--border);
       background: var(--surface);
       color: var(--muted);
-      font-size: 13px;
-      line-height:1.35;
+      font-size: 15px;
+      line-height:1.5;
     }
     .ctaRow{display:flex;gap:10px;flex-wrap:wrap;margin-top:6px}
     .fine{
       margin-top:12px;
       color: var(--muted2);
-      font-size: 12px;
-      line-height:1.45;
+      font-size: 13.5px;
+      line-height:1.55;
     }
     @media (max-width: 640px){
-      body{font-size:16px;line-height:1.65;}
-      .sub{line-height:1.65;font-size:16.5px;}
-      .sectionTitle p{line-height:1.6;font-size:15.5px;}
-      .bullet{line-height:1.5;font-size:15px;}
-      .fine{line-height:1.6;font-size:13.5px;}
+      body{font-size:17px;line-height:1.65;}
+      .sub{line-height:1.65;font-size:17px;}
+      .sectionTitle p{line-height:1.6;font-size:16px;}
+      .bullet{line-height:1.55;font-size:15.5px;}
+      .fine{line-height:1.6;font-size:14px;}
     }
     @media (max-width: 430px){
-      body{font-size:16.5px;line-height:1.7;}
+      body{font-size:17.5px;line-height:1.7;}
       .btn,
       .btnSm,
       .btnXL,
@@ -267,7 +269,7 @@
       }
       .btn{padding:14px 16px;}
       .btnSm{padding:12px 14px;}
-      .sub{font-size:17px;line-height:1.7;}
+      .sub{font-size:17.5px;line-height:1.7;}
       .sectionTitle p,
       .list,
       .checkBullets,
@@ -278,7 +280,7 @@
       .videoShell .hint p,
       .gText,
       .gList{
-        font-size:16px;
+        font-size:16.5px;
         line-height:1.65;
       }
       .bullet,
@@ -287,7 +289,7 @@
       .fine,
       .trustPoints li,
       .check span{
-        font-size:15.5px;
+        font-size:16px;
         line-height:1.6;
       }
       .pill{font-size:13px;line-height:1.3;}
@@ -465,10 +467,10 @@
     }
     .sectionTitle p{
       margin:0;
-      color: rgba(71,85,105,.8);
-      font-size: 13px;
+      color: rgba(226,232,240,.92);
+      font-size: 15.5px;
       max-width: 62ch;
-      line-height:1.5;
+      line-height:1.6;
     }
     .grid2{display:grid;grid-template-columns:1fr 1fr;gap:14px}
     .grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
@@ -573,9 +575,9 @@
     .list{
       margin:10px 0 0;
       padding:0 0 0 18px;
-      color: var(--muted2);
-      line-height:1.55;
-      font-size: 14px;
+      color: var(--muted);
+      line-height:1.6;
+      font-size: 15.5px;
     }
     .callout{
       margin-top:14px;
@@ -584,8 +586,8 @@
       border:1px solid rgba(22,163,74,.20);
       background: rgba(22,163,74,.08);
       color: var(--text);
-      font-size: 13px;
-      line-height:1.45;
+      font-size: 14.5px;
+      line-height:1.55;
     }
 
     /* Extra blocks for product descriptions (premium, sin alterar colores) */
@@ -597,8 +599,8 @@
     .subcopyLead{
       margin:0;
       color: var(--muted);
-      font-size: 13px;
-      line-height:1.55;
+      font-size: 14.5px;
+      line-height:1.6;
     }
     .subcopyNote{
       margin:10px 0 0;
@@ -611,8 +613,8 @@
       padding:0;
       margin:10px 0 0;
       color: var(--muted2);
-      line-height:1.45;
-      font-size: 14px;
+      line-height:1.55;
+      font-size: 15px;
     }
     .checkBullets li{
       display:flex;
@@ -658,7 +660,7 @@
     }
     input:focus{border-color: var(--cta); box-shadow: 0 0 0 4px rgba(22,163,74,.14)}
     .formActions{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px}
-    .consent{font-size:12px;color: var(--muted2);line-height:1.4;margin-top:10px}
+    .consent{font-size:13.5px;color: rgba(203,213,225,.95);line-height:1.55;margin-top:10px}
 
     /* Test */
     .testGrid{
@@ -799,14 +801,14 @@
       border:1px solid var(--border);
       background:var(--surface);
       color:var(--muted);
-      font-size:12px;
+      font-size:13px;
       position:relative;
       z-index:1;
     }
-    .trustTitle{margin:10px 0 8px;font-size:18px;letter-spacing:-.2px;position:relative;z-index:1}
-    .trustText{margin:0;color:rgba(71,85,105,.85);font-size:14px;line-height:1.55;position:relative;z-index:1}
+    .trustTitle{margin:10px 0 8px;font-size:20px;letter-spacing:-.2px;position:relative;z-index:1}
+    .trustText{margin:0;color:rgba(71,85,105,.85);font-size:15.5px;line-height:1.6;position:relative;z-index:1}
     .trustPoints{margin:14px 0 0;padding:0;list-style:none;display:flex;flex-direction:column;gap:10px;position:relative;z-index:1}
-    .trustPoints li{display:flex;gap:10px;align-items:flex-start;color:rgba(71,85,105,.88);font-size:13px;line-height:1.45}
+    .trustPoints li{display:flex;gap:10px;align-items:flex-start;color:rgba(71,85,105,.88);font-size:14.5px;line-height:1.55}
     .trustDot{
       width:22px;height:22px;border-radius:8px;
       background: rgba(22,163,74,.14);
@@ -820,13 +822,13 @@
     .trustActions{display:flex;gap:10px;flex-wrap:wrap;margin-top:14px;position:relative;z-index:1;justify-content:center}
     .trustActionsRow{grid-column:1 / -1; justify-content:center; margin-top:6px;}
     .trustActionsRow .btn{min-width:200px; text-align:center; padding:12px 16px;}
-    .trustFine{margin-top:10px;color:rgba(71,85,105,.65);font-size:12px;line-height:1.4;position:relative;z-index:1}
+    .trustFine{margin-top:10px;color:rgba(71,85,105,.65);font-size:13.5px;line-height:1.5;position:relative;z-index:1}
     .trustChipRow{display:flex;gap:8px;flex-wrap:wrap;margin-top:12px;position:relative;z-index:1}
     .trustChip{
       padding:6px 10px;border-radius:999px;
       border:1px solid var(--border);
       background:var(--surface);
-      font-size:12px;color:var(--muted);
+      font-size:13px;color:var(--muted);
       transition: transform var(--anim-fast) ease, box-shadow var(--anim-fast) ease, background var(--anim-fast) ease, border-color var(--anim-fast) ease, color var(--anim-fast) ease;
     }
 
@@ -886,6 +888,9 @@
       font-size:18px !important;
       line-height:1.55 !important;
     }
+    #confianza .sectionTitle{align-items:center;}
+    #confianza .sectionTitle p{color:rgba(226,232,240,.95) !important;font-size:16px !important;line-height:1.6 !important;}
+    #confianza .sectionTitle h2{font-size: clamp(20px, 2.4vw, 30px);}
     #confianza .trustTile,
     #confianza .trustCard,
     #confianza .trustItem{
@@ -1022,10 +1027,10 @@
     }
 
     /* PDR legible (el tile usa b/span, no h3/p) */
-    #confianza .pdrTxt b{color:#0B1220 !important;}
-    #confianza .pdrTxt span,
-    #confianza .pdrTxt em,
-    #confianza .trustBoard .hintLine{color:#334155 !important; opacity:1 !important;}
+    #confianza .pdrTxt b{color:#0B1220 !important;font-size:20px !important;letter-spacing:-.2px !important;}
+    #confianza .pdrTxt span{color:#1F2937 !important; opacity:1 !important;font-size:15px !important;line-height:1.4 !important;}
+    #confianza .pdrTxt em{color:#1F2937 !important; opacity:1 !important;font-size:13.5px !important;line-height:1.4 !important;}
+    #confianza .trustBoard .hintLine{color:#1F2937 !important; opacity:1 !important;font-size:13px !important;}
 
     #confianza .certTxt strong{
       color:#FFFFFF !important;
@@ -1052,17 +1057,17 @@
     .pdrBoard{justify-content:center; gap:10px;}
     .pdrRow{display:flex;align-items:center;gap:10px}
     .pdrIcon{
-      width:58px;height:58px;border-radius:16px;
-      background: rgba(22,163,74,.14);
-      border:1px solid rgba(22,163,74,.35);
+      width:64px;height:64px;border-radius:18px;
+      background: rgba(22,163,74,.18);
+      border:1px solid rgba(22,163,74,.45);
       display:flex;align-items:center;justify-content:center;
       box-shadow: 0 14px 26px rgba(15,23,42,.12);
       flex:0 0 auto;
     }
-    .pdrIcon svg{width:30px;height:30px;fill:none;stroke:rgba(22,163,74,.95);stroke-width:1.9;stroke-linecap:round;stroke-linejoin:round}
-    .pdrTxt b{display:block;font-size:18px;letter-spacing:-.2px}
-    .pdrTxt span{display:block;margin-top:3px;color:rgba(71,85,105,.86);font-size:12px;line-height:1.25}
-    .pdrTxt em{display:block;margin-top:6px;color:rgba(71,85,105,.72);font-size:11px;font-style:normal;line-height:1.25}
+    .pdrIcon svg{width:34px;height:34px;fill:none;stroke:rgba(22,163,74,.98);stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
+    .pdrTxt b{display:block;font-size:20px;letter-spacing:-.2px}
+    .pdrTxt span{display:block;margin-top:4px;color:rgba(71,85,105,.9);font-size:14px;line-height:1.35}
+    .pdrTxt em{display:block;margin-top:6px;color:rgba(71,85,105,.78);font-size:12.5px;font-style:normal;line-height:1.35}
 
     /* Certificaciones */
     .certBoard{gap:10px}
@@ -1098,6 +1103,52 @@
     .trustCap{padding:14px 16px}
     .trustCap strong{display:block;font-size:14px}
     .trustCap span{display:block;margin-top:4px;color:rgba(71,85,105,.78);font-size:12.5px;line-height:1.35}
+    #confianza .trustCap strong{font-size:18px !important;line-height:1.4 !important;}
+    #confianza .trustCap span{font-size:15px !important;line-height:1.5 !important;color:#E2E8F0 !important;}
+
+    #confianza .trustBrief{
+      background: linear-gradient(180deg, rgba(11,18,32,.92), rgba(11,18,32,.8));
+      border-color: rgba(148,163,184,.28);
+    }
+    #confianza .trustBrief .trustKicker{
+      background: rgba(15,23,42,.75);
+      border-color: rgba(148,163,184,.35);
+      color:#E2E8F0 !important;
+    }
+    #confianza .trustBrief .trustTitle,
+    #confianza .trustBrief .trustText,
+    #confianza .trustBrief .trustPoints li,
+    #confianza .trustBrief .trustFine{
+      color:#E2E8F0 !important;
+    }
+    #confianza .trustBrief .trustText{font-size:16px !important;line-height:1.6 !important;}
+    #confianza .trustBrief .trustChip{
+      background: rgba(15,23,42,.75) !important;
+      border-color: rgba(148,163,184,.35) !important;
+      color:#E2E8F0 !important;
+    }
+    #confianza .trustBrief .trustActionsRow .btnGhost{
+      background: rgba(15,23,42,.98) !important;
+      border-color: rgba(226,232,240,.3) !important;
+      color:#F8FAFC !important;
+      box-shadow: 0 12px 30px rgba(0,0,0,.35) !important;
+    }
+
+    #incluye .sectionTitle p{
+      color:rgba(226,232,240,.95);
+      font-size:16px;
+      line-height:1.6;
+    }
+    #incluye .sectionTitle h2{font-size: clamp(20px, 2.4vw, 30px);}
+
+    .hero .card .cardPad > div > div > div:nth-child(2){
+      color: rgba(226,232,240,.95) !important;
+      font-size: 14.5px !important;
+      line-height:1.55 !important;
+    }
+    .hero .card .cardPad > div > div > div:nth-child(2) strong{
+      color:#F8FAFC;
+    }
 
     /* Garantía */
     .guaranteeCard{


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad para audiencia 35–40+ en desktop y móvil sin romper la estética dark premium. 
- Aumentar la escala tipográfica base y `line-height` para lectura más cómoda en cuerpos de texto y microcopy. 
- Elevar el contraste y la jerarquía de los textos grises que resultaban difíciles de leer en secciones clave (Incluye / Respaldo / PDR / microcopy WhatsApp). 
- Mantener `prefers-reduced-motion` y no alterar estructura HTML ni copy.

### Description
- Cambios CSS-only en `landing_venta.html` dentro del bloque `<style>` para subir la tipografía global (`body` font-size, `line-height`) y ajustar escalas en `.sub`, `.sectionTitle p`, `.list`, `.bullet`, `.fine`, `.consent` y puntos móviles. 
- Reforzada la sección `#confianza` y `trustBrief` (colores, fondo, chips, acciones) para mayor contraste y lectura, además de centrar/ajustar jerarquía de título y párrafo. 
- Mejorada la tarjeta PDR: aumenté tamaño del icono `.pdrIcon`, tipografías en `.pdrTxt` y la `hintLine` para que el CTA/indicador sea más visible y premium. 
- Ajustes responsivos: aumentos puntuales en media queries para móviles pequeños para conservar legibilidad sin romper el diseño.

### Testing
- Se sirvió la página localmente con `python -m http.server` y se capturó una captura de pantalla de página completa usando Playwright (`page.screenshot`) como prueba visual automática; la captura se generó correctamente. 
- No se ejecutaron suites de pruebas unitarias porque son cambios estáticos de HTML/CSS solamente. 
- Ninguna otra prueba automatizada fue necesaria para estos ajustes estéticos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954412f7e7c8325927e8d3158788b3c)