### PR TITLE
UI: fix legibilidad residual + limpiar header video

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -315,6 +315,9 @@
       border:1px solid rgba(255,255,255,.10);
       box-shadow: 0 8px 18px rgba(0,0,0,.18);
     }
+    .videoShell .videoTop{
+      justify-content:flex-end;
+    }
     .videoActions{display:flex;align-items:center;gap:10px}
     .btnSm{padding:10px 12px;border-radius:12px;font-size:13px}
     @media (max-width: 520px){
@@ -1028,9 +1031,13 @@
 
     /* PDR legible (el tile usa b/span, no h3/p) */
     #confianza .pdrTxt b{color:#0B1220 !important;font-size:20px !important;letter-spacing:-.2px !important;}
-    #confianza .pdrTxt span{color:#1F2937 !important; opacity:1 !important;font-size:15px !important;line-height:1.4 !important;}
-    #confianza .pdrTxt em{color:#1F2937 !important; opacity:1 !important;font-size:13.5px !important;line-height:1.4 !important;}
+    #confianza .pdrTxt span{color:#0F172A !important; opacity:1 !important;font-size:15px !important;line-height:1.4 !important;font-weight:600 !important;}
+    #confianza .pdrTxt em{color:#0F172A !important; opacity:1 !important;font-size:13.5px !important;line-height:1.4 !important;font-weight:600 !important;}
     #confianza .trustBoard .hintLine{color:#1F2937 !important; opacity:1 !important;font-size:13px !important;}
+    #confianza .trustBoard .hintLine{
+      color:#0B1220 !important;
+      font-weight:700 !important;
+    }
 
     #confianza .certTxt strong{
       color:#FFFFFF !important;
@@ -1063,6 +1070,13 @@
       display:flex;align-items:center;justify-content:center;
       box-shadow: 0 14px 26px rgba(15,23,42,.12);
       flex:0 0 auto;
+    }
+    #confianza .pdrIcon{
+      background: rgba(22,163,74,.24);
+      border-color: rgba(22,163,74,.72);
+      box-shadow:
+        0 0 0 1px rgba(11,18,32,.25),
+        0 16px 28px rgba(15,23,42,.18);
     }
     .pdrIcon svg{width:34px;height:34px;fill:none;stroke:rgba(22,163,74,.98);stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
     .pdrTxt b{display:block;font-size:20px;letter-spacing:-.2px}
@@ -1162,6 +1176,18 @@
     @media (max-width:640px){
       .guaranteePad{align-items:flex-start}
       .guaranteeTitle{font-size:17px}
+    }
+    #comprar .cardPad > p[style*="rgba(71,85,105"]{
+      color: rgba(226,232,240,.88) !important;
+    }
+    #comprar .cardPad > p[style*="rgba(71,85,105"] strong{
+      color: rgba(248,250,252,.96);
+    }
+    .guaranteeCard .guaranteeSub{
+      color: rgba(226,232,240,.86);
+    }
+    .guaranteeCard .fine{
+      color: rgba(226,232,240,.7);
     }
     /* Garantía modal */
     .gOverlay{
@@ -1376,7 +1402,6 @@
 
       <div class="panel videoShell">
         <div class="videoTop">
-          <div class="videoTitle"><span class="pulse"></span> Video de Rafael (abre con intención)</div>
           <div class="videoActions">
             <span class="badge">Cinemático · premium</span>
             <button class="btn btnGhost btnSm" type="button" id="openVideoTools">Subir mi video</button>


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad de bloques críticos (PDR, garantías, opciones de compra) sin romper la estética dark premium existente.
- Quitar el texto redundante del header del video para dejar solo el botón de `Subir mi video` bien alineado.
- Aumentar el contraste de iconos y microcopy en la sección de `#confianza` (PDR / certificaciones) para que el CTA "Click para abrir" sea más visible.
- Mantener cambios mínimos y CSS-first; modificar el HTML solo para eliminar el texto del header del video.

### Description
- Editado únicamente `landing_venta.html` para eliminar el texto del header del video y dejar el botón visible; no se tocaron IDs, funciones ni lógica JS.
- Alineación del header de video ajustada con la regla CSS añadida ` .videoShell .videoTop { justify-content: flex-end; }` para que el botón quede aislado a la derecha.
- Mejorado contraste PDR: `#confianza .pdrTxt span` y `em` ahora usan color más oscuro y peso mayor, y `#confianza .trustBoard .hintLine` se refuerza con color y `font-weight:700` para el "Click para abrir".
- Icono PDR reforzado añadiendo `#confianza .pdrIcon` con fondo más visible, borde más marcado y sombra sutil; además se ajustaron colores en `#comprar` y `.guaranteeCard` para subir la legibilidad de `Opción 1/2` y textos de la garantía.

### Testing
- Levantado servidor local con `python -m http.server 8000` para servir la página y verificar visualmente; el servidor arrancó correctamente.
- Captura de pantalla automatizada con Playwright generada en `artifacts/landing-venta-ui-fixes.png` para inspección visual automática; la captura se creó con éxito.
- No se ejecutaron tests unitarios porque los cambios son solo HTML/CSS estáticos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69544fb263948325bd8d8d15ffb92de6)