### PR TITLE
UI: hotfix tabs — bordes color visibles (Ciencia/Historia/Oportunidad)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1008,39 +1008,42 @@
       font-weight:900 !important;
       letter-spacing:.2px !important;
     }
-    #confianza .trustActionsRow .btn:nth-child(1){--tab-accent: rgb(37,99,235);}  /* azul */
-    #confianza .trustActionsRow .btn:nth-child(2){--tab-accent: rgb(11,107,58);}  /* verde */
-    #confianza .trustActionsRow .btn:nth-child(3){--tab-accent: rgb(242,140,40);} /* naranja */
+    #confianza .trustActionsRow > :is(a, button):nth-of-type(1){--tab-accent: rgb(37,99,235);}  /* azul */
+    #confianza .trustActionsRow > :is(a, button):nth-of-type(2){--tab-accent: rgb(11,107,58);}  /* verde */
+    #confianza .trustActionsRow > :is(a, button):nth-of-type(3){--tab-accent: rgb(242,140,40);} /* naranja */
 
+    #confianza .trustActionsRow :is(a, button){
+      border:2px solid var(--tab-accent, #64748b) !important;
+    }
     #confianza .trustActionsRow .btnGhost{
       background: rgba(11,18,32,.92) !important;
       color:#F8FAFC !important;
-      border:1px solid var(--tab-accent) !important;
+      border:2px solid var(--tab-accent, #64748b) !important;
       box-shadow:
-        0 0 0 1px color-mix(in srgb, var(--tab-accent) 40%, transparent),
+        0 0 0 1px color-mix(in srgb, var(--tab-accent, #64748b) 35%, transparent),
         0 12px 26px rgba(0,0,0,.18) !important;
     }
     @media (hover:hover){
       #confianza .trustActionsRow .btnGhost:hover{
         transform: translateY(-2px) !important;
         box-shadow:
-          0 0 0 2px color-mix(in srgb, var(--tab-accent) 65%, transparent),
-          0 0 12px color-mix(in srgb, var(--tab-accent) 32%, transparent),
+          0 0 0 2px color-mix(in srgb, var(--tab-accent, #64748b) 70%, transparent),
+          0 0 12px color-mix(in srgb, var(--tab-accent, #64748b) 38%, transparent),
           0 18px 34px rgba(0,0,0,.22) !important;
       }
     }
     #confianza .trustActionsRow .btnGhost:active{
       box-shadow:
-        0 0 0 2px color-mix(in srgb, var(--tab-accent) 65%, transparent),
-        0 0 10px color-mix(in srgb, var(--tab-accent) 30%, transparent),
+        0 0 0 2px color-mix(in srgb, var(--tab-accent, #64748b) 70%, transparent),
+        0 0 10px color-mix(in srgb, var(--tab-accent, #64748b) 34%, transparent),
         0 14px 28px rgba(0,0,0,.2) !important;
     }
     #confianza .trustActionsRow .btnGhost:focus-visible{
       outline:2px solid rgba(255,255,255,.95);
       outline-offset:2px;
       box-shadow:
-        0 0 0 2px color-mix(in srgb, var(--tab-accent) 65%, transparent),
-        0 0 12px color-mix(in srgb, var(--tab-accent) 32%, transparent),
+        0 0 0 2px color-mix(in srgb, var(--tab-accent, #64748b) 70%, transparent),
+        0 0 12px color-mix(in srgb, var(--tab-accent, #64748b) 38%, transparent),
         0 14px 28px rgba(0,0,0,.2) !important;
     }
 


### PR DESCRIPTION
### Motivation
- Garantizar que los 3 tabs (Ciencia / Historia / Oportunidad) muestren borde de color en reposo porque el selector anterior aplicaba el color de forma incorrecta.
- Evitar tocar HTML o JS y aplicar la corrección únicamente en CSS dentro de `landing_venta.html`.
- Asignar colores por posición real del elemento en la fila de tabs para que el color no dependa de clases accidentales.

### Description
- Editado solo `landing_venta.html` dentro del bloque de estilos para mantener el cambio CSS-only y sin tocar HTML/JS.
- Reemplacé las reglas basadas en `:nth-child()` sobre `.btn` por `#confianza .trustActionsRow > :is(a, button):nth-of-type(n)` para fijar `--tab-accent` en cada posición y usar los tres colores solicitados.
- Añadí `#confianza .trustActionsRow :is(a, button){ border:2px solid var(--tab-accent, #64748b) !important; }` para forzar borde visible con fallback gris y mantuve/ajusté los `box-shadow`/glow para reposo, hover, active y `:focus-visible` usando el fallback `var(--tab-accent, #64748b)`.
- Incrementé el grosor a `2px` y uniformicé los `color-mix` fallback para asegurar una presencia sutil en reposo y ligeramente más fuerte en hover/active.

### Testing
- Levanté un servidor estático con `python -m http.server` y abrí `landing_venta.html` con Playwright para capturar una captura de pantalla; la navegación y la captura completaron correctamente y generaron `tabs-confianza.png`.
- Se verificó que solo `landing_venta.html` fue modificado y los cambios fueron añadidos y confirmados con `git commit` exitoso.
- No se ejecutaron pruebas de CI/unitarias automáticas en este PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954608816e88325a51fe1d9429924a1)