### PR TITLE
UI-26: Eliminar 'Testimonio en video más abajo' (mínimo)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1670,7 +1670,7 @@ a.card.trustTile .pdrBoard{
                     </div>
                 <span class="badge">Datos mínimos · Sin estrés</span>
               </div>
-                  <div class="badge" style="margin-top:8px">Testimonio en video más abajo</div>
+                  
 
               <form id="leadForm" autocomplete="on">
                 <div style="position:absolute;left:-9999px;opacity:0;pointer-events:none" aria-hidden="true">


### PR DESCRIPTION
Cambio mínimo: se elimina del landing el elemento que muestra 'Testimonio en video más abajo'. No se toca nada más.