### PR TITLE
UI-27: Restaurar bordes teal tabs Unicity (solo borde)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1973,9 +1973,9 @@ a.card.trustTile .pdrBoard{
             </a>
 
             <div class="trustActions trustActionsRow">
-              <a class="btn btnGhost" href="https://www.unicityscience.org/clinical-validation-studies/?lang=es" target="_blank" rel="noopener noreferrer">Ciencia de Unicity</a>
-              <a class="btn btnGhost" href="https://www.unicity.com/mex/es/learn/history" target="_blank" rel="noopener noreferrer">Historia de Unicity</a>
-              <a class="btn btnGhost" href="https://www.unicity.com/usa/es/opportunity" target="_blank" rel="noopener noreferrer">Oportunidad de negocio</a>
+              <a class="btn btnGhost" href="https://www.unicityscience.org/clinical-validation-studies/?lang=es" target="_blank" rel="noopener noreferrer" style="border:2px solid #2DD4BF !important;">Ciencia de Unicity</a>
+              <a class="btn btnGhost" href="https://www.unicity.com/mex/es/learn/history" target="_blank" rel="noopener noreferrer" style="border:2px solid #2DD4BF !important;">Historia de Unicity</a>
+              <a class="btn btnGhost" href="https://www.unicity.com/usa/es/opportunity" target="_blank" rel="noopener noreferrer" style="border:2px solid #2DD4BF !important;">Oportunidad de negocio</a>
             </div>
 
               <a class="card trustTile" href="https://www.pdr.net/full-prescribing-information/hl/?druglabelid=24170" target="_blank" rel="noopener" aria-label="Abrir evidencia PDR">


### PR DESCRIPTION
Cambio mínimo: se restablece borde teal #2DD4BF (!important) en los 3 tabs Unicity (Ciencia/Historia/Oportunidad) por URL. No se toca nada más.