### PR TITLE
Lead-gate Test Metabólico: bloqueo hasta Nombre+Email, compartir con link y saludo personalizado

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -18,20 +18,21 @@
     :root{
       /* Design Tokens */
       --font-base: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
-      --bg:#07131A;
-      --surface:#0E1F2A;
-      --surface-strong:#122A38;
-      --surface-contrast:#0B1A24;
-      --text:#F8FAFC;
-      --muted:#B6C2CF;
-      --muted2:#93A4B8;
-      --border: rgba(255,255,255,.12);
-      --line: rgba(255,255,255,.10);
-      --cta:#F97316;
-      --cta-hover:#EA580C;
-      --link:#60A5FA;
+      --bg:#0B2B34;
+      --surface:#0F3A45;
+      --surface-strong:#14515D;
+      --surface-contrast:#0A262E;
+      --text:#FFFFFF;
+      --muted:#C7D5DB;
+      --muted2:#A9BAC4;
+      --border: rgba(255,255,255,.16);
+      --line: rgba(255,255,255,.12);
+      --cta:#F28C28;
+      --cta-hover:#E27C1D;
+      --link:#7FE3B3;
       --error:#EF4444;
-      --success:#22C55E;
+      --success:#0B6B3A;
+      --graphite:#1F1F1F;
       --shadow: 0 20px 60px rgba(0,0,0,.35);
       --shadow-soft: 0 12px 36px rgba(0,0,0,.28);
       --radius: 16px;
@@ -52,18 +53,18 @@
       margin:0;
       font-family: var(--font-base);
       color: var(--text);
-      font-size:17px;
-      line-height:1.6;
+      font-size:18px;
+      line-height:1.7;
       background-color: var(--bg);
       background:
-        radial-gradient(1200px 620px at 18% 12%, rgba(249,115,22,.14), transparent 55%),
-        radial-gradient(900px 520px at 70% 0%, rgba(96,165,250,.12), transparent 55%),
-        linear-gradient(180deg, var(--bg) 0%, #0B1A24 55%, var(--bg) 100%);
+        radial-gradient(1200px 620px at 18% 12%, rgba(11,107,58,.18), transparent 55%),
+        radial-gradient(900px 520px at 70% 0%, rgba(11,43,52,.22), transparent 55%),
+        linear-gradient(180deg, #0B2B34 0%, #0A2229 55%, #0B2B34 100%);
       overflow-x:hidden;
     }
     a{color:var(--link)}
     a:focus-visible{
-      outline:2px solid rgba(96,165,250,.95);
+      outline:2px solid rgba(127,227,179,.95);
       outline-offset:2px;
       border-radius:8px;
     }
@@ -74,7 +75,7 @@
       position:sticky;top:0;z-index:50;
       backdrop-filter: blur(12px);
       -webkit-backdrop-filter: blur(12px);
-      background: rgba(7,19,26,.9);
+      background: rgba(11,43,52,.92);
       border-bottom: 1px solid var(--border);
       box-shadow: 0 10px 30px rgba(0,0,0,.35);
     }
@@ -115,8 +116,8 @@
     }
     .btn{
       border:1px solid transparent;cursor:pointer;
-      padding:12px 14px;border-radius:12px;
-      font-weight:700;
+      padding:14px 16px;border-radius:14px;
+      font-weight:800;
       transition: transform var(--anim-fast) ease, filter var(--anim-fast) ease, background var(--anim-fast) ease, box-shadow var(--anim-fast) ease, border-color var(--anim-fast) ease, color var(--anim-fast) ease;
       text-decoration:none;
       display:inline-flex;align-items:center;justify-content:center;gap:10px;
@@ -128,36 +129,36 @@
     .btn:focus-visible{
       outline:2px solid rgba(248,250,252,.95);
       outline-offset:2px;
-      box-shadow:0 0 0 4px rgba(37,99,235,.18);
+      box-shadow:0 0 0 4px rgba(11,107,58,.18);
     }
     .btn:disabled,
     .btn[aria-busy="true"]{
       opacity:.75;cursor:not-allowed;filter:grayscale(.1);
     }
     .btnPrimary{
-      background: var(--cta);
+      background: linear-gradient(135deg, rgba(242,140,40,1), rgba(240,124,18,1));
       color:#fff;
       border-color: var(--cta);
-      box-shadow: 0 14px 32px rgba(249,115,22,.18);
+      box-shadow: 0 16px 34px rgba(242,140,40,.22);
     }
-    .btnPrimary:hover{background: var(--cta-hover);border-color: var(--cta-hover);}
+    .btnPrimary:hover{background: linear-gradient(135deg, rgba(242,140,40,1), rgba(226,124,29,1));border-color: var(--cta-hover);}
     .btnPrimary:focus-visible{
       outline:2px solid rgba(255,255,255,.95);
       outline-offset:2px;
-      box-shadow:0 0 0 4px rgba(249,115,22,.22);
+      box-shadow:0 0 0 4px rgba(242,140,40,.22);
     }
 
     .btnSecondary{
-      background: #25D366;
+      background: #0B6B3A;
       color: #fff;
-      border-color: #25D366;
-      box-shadow: 0 10px 24px rgba(37,211,102,.16);
+      border-color: #0B6B3A;
+      box-shadow: 0 12px 26px rgba(11,107,58,.22);
     }
-    .btnSecondary:hover{background: #1EBE5D;border-color:#1EBE5D;}
+    .btnSecondary:hover{background: #0A5E33;border-color:#0A5E33;}
     .btnSecondary:focus-visible{
       outline:2px solid rgba(255,255,255,.95);
       outline-offset:2px;
-      box-shadow:0 0 0 4px rgba(37,211,102,.22);
+      box-shadow:0 0 0 4px rgba(11,107,58,.22);
     }
 
     .btnGhost{
@@ -204,16 +205,16 @@
     }
     h1{
       margin:0 0 10px;
-      font-size: clamp(28px, 3.6vw, 44px);
-      line-height:1.08;
+      font-size: clamp(30px, 3.8vw, 48px);
+      line-height:1.12;
       letter-spacing:-.5px;
       font-weight:800;
     }
     .sub{
       margin:0 0 16px;
       color: var(--muted);
-      font-size: 17px;
-      line-height:1.6;
+      font-size: 18px;
+      line-height:1.7;
       max-width: 62ch;
     }
     .kicker{
@@ -241,35 +242,35 @@
       border:1px solid var(--border);
       background: var(--surface);
       color: var(--muted);
-      font-size: 15px;
-      line-height:1.5;
+      font-size: 16px;
+      line-height:1.6;
     }
-    .ctaRow{display:flex;gap:10px;flex-wrap:wrap;margin-top:6px}
+    .ctaRow{display:flex;gap:12px;flex-wrap:wrap;margin-top:8px}
     .fine{
       margin-top:12px;
       color: var(--muted2);
-      font-size: 13.5px;
-      line-height:1.55;
+      font-size: 14.5px;
+      line-height:1.6;
     }
     @media (max-width: 640px){
-      body{font-size:17px;line-height:1.65;}
-      .sub{line-height:1.65;font-size:17px;}
-      .sectionTitle p{line-height:1.6;font-size:16px;}
-      .bullet{line-height:1.55;font-size:15.5px;}
-      .fine{line-height:1.6;font-size:14px;}
+      body{font-size:18px;line-height:1.7;}
+      .sub{line-height:1.7;font-size:18px;}
+      .sectionTitle p{line-height:1.65;font-size:16.5px;}
+      .bullet{line-height:1.6;font-size:16px;}
+      .fine{line-height:1.6;font-size:14.5px;}
     }
     @media (max-width: 430px){
-      body{font-size:17.5px;line-height:1.7;}
+      body{font-size:18.5px;line-height:1.72;}
       .btn,
       .btnSm,
       .btnXL,
       .trustActionsRow .btn{
-        font-size:18px;
+        font-size:18.5px;
         line-height:1.3;
       }
       .btn{padding:14px 16px;}
       .btnSm{padding:12px 14px;}
-      .sub{font-size:17.5px;line-height:1.7;}
+      .sub{font-size:18px;line-height:1.7;}
       .sectionTitle p,
       .list,
       .checkBullets,
@@ -280,7 +281,7 @@
       .videoShell .hint p,
       .gText,
       .gList{
-        font-size:16.5px;
+        font-size:17px;
         line-height:1.65;
       }
       .bullet,
@@ -289,7 +290,7 @@
       .fine,
       .trustPoints li,
       .check span{
-        font-size:16px;
+        font-size:16.5px;
         line-height:1.6;
       }
       .pill{font-size:13px;line-height:1.3;}
@@ -301,19 +302,19 @@
       height: 100%;
       min-height: 430px;
       background:
-        radial-gradient(520px 320px at 28% 10%, rgba(22,163,74,.12), transparent 60%),
-        radial-gradient(520px 320px at 75% 0%, rgba(37,99,235,.08), transparent 60%),
-        linear-gradient(180deg, #f7f9fb 0%, #eef2f6 100%);
+        radial-gradient(520px 320px at 28% 10%, rgba(11,107,58,.16), transparent 60%),
+        radial-gradient(520px 320px at 75% 0%, rgba(11,43,52,.18), transparent 60%),
+        linear-gradient(180deg, #f8fbfc 0%, #eef4f6 100%);
     }
     .videoTop{
       display:flex;align-items:center;justify-content:space-between;gap:10px;
       padding:12px 14px 8px;
       color: #F8FAFC;
-      background: linear-gradient(180deg, rgba(11,18,32,.65), rgba(11,18,32,.15));
-      border-radius: 14px 14px 0 0;
+      background: linear-gradient(180deg, rgba(11,43,52,.85), rgba(11,43,52,.25));
+      border-radius: 18px 18px 0 0;
       margin:0 16px 0;
       border:1px solid rgba(255,255,255,.10);
-      box-shadow: 0 8px 18px rgba(0,0,0,.18);
+      box-shadow: 0 10px 22px rgba(0,0,0,.18);
     }
     .videoShell .videoTop{
       justify-content:flex-end;
@@ -333,23 +334,23 @@
     }
     .pulse{
       width:10px;height:10px;border-radius:999px;
-      background: var(--cta);
-      box-shadow: 0 0 0 0 rgba(22,163,74,.35);
+      background: var(--success);
+      box-shadow: 0 0 0 0 rgba(11,107,58,.35);
       animation:pulse 1.6s infinite;
     }
     @keyframes pulse{
-      0%{box-shadow:0 0 0 0 rgba(22,163,74,.35)}
-      70%{box-shadow:0 0 0 14px rgba(22,163,74,0)}
-      100%{box-shadow:0 0 0 0 rgba(22,163,74,0)}
+      0%{box-shadow:0 0 0 0 rgba(11,107,58,.35)}
+      70%{box-shadow:0 0 0 14px rgba(11,107,58,0)}
+      100%{box-shadow:0 0 0 0 rgba(11,107,58,0)}
     }
     .videoFrame{
       position:relative;
       margin:14px 16px 16px;
-      border-radius: 18px;
+      border-radius: 22px;
       overflow:hidden;
-      border:1px solid var(--border);
-      background: var(--surface-contrast);
-      box-shadow: var(--shadow-soft);
+      border:1px solid rgba(11,43,52,.35);
+      background: #071C22;
+      box-shadow: 0 20px 48px rgba(8,20,26,.35);
       height: min(72vh, 560px);
       aspect-ratio: 9 / 16;
       max-width: 360px;
@@ -379,8 +380,8 @@
     .videoOverlay{
       position:absolute;inset:0;
       background:
-        radial-gradient(520px 300px at 30% 0%, rgba(22,163,74,.12), transparent 60%),
-        linear-gradient(180deg, rgba(255,255,255,.55), rgba(247,248,250,.9));
+        radial-gradient(520px 300px at 30% 0%, rgba(11,107,58,.14), transparent 60%),
+        linear-gradient(180deg, rgba(255,255,255,.6), rgba(246,249,250,.95));
       display:flex;align-items:flex-end;
       padding:16px;
     }
@@ -391,11 +392,11 @@
     }
     .playCircle{
       width:86px;height:86px;border-radius:999px;
-      background: var(--cta);
+      background: var(--success);
       color:#fff;
       display:flex;align-items:center;justify-content:center;
-      box-shadow: 0 16px 36px rgba(22,163,74,.22);
-      border: 1px solid rgba(255,255,255,.8);
+      box-shadow: 0 18px 40px rgba(11,107,58,.28);
+      border: 1px solid rgba(255,255,255,.85);
       transform: translateY(-8px);
       transition: transform .16s ease, filter .16s ease;
     }
@@ -434,8 +435,8 @@
       border-radius:16px;
       padding:16px 18px;
       color: var(--muted);
-      font-size:16px;
-      line-height:1.55;
+      font-size:16.5px;
+      line-height:1.6;
       box-shadow: 0 12px 32px rgba(15,23,42,.10);
       margin: 0 16px 16px;
     }
@@ -464,16 +465,16 @@
     }
     .sectionTitle h2{
       margin:0;
-      font-size: clamp(18px, 2.2vw, 28px);
+      font-size: clamp(20px, 2.4vw, 30px);
       letter-spacing:-.2px;
       font-weight:800;
     }
     .sectionTitle p{
       margin:0;
       color: rgba(226,232,240,.92);
-      font-size: 15.5px;
+      font-size: 16.5px;
       max-width: 62ch;
-      line-height:1.6;
+      line-height:1.65;
     }
     .grid2{display:grid;grid-template-columns:1fr 1fr;gap:14px}
     .grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
@@ -489,7 +490,11 @@
       transition: transform var(--anim-fast) ease, box-shadow var(--anim-fast) ease, border-color var(--anim-fast) ease, background var(--anim-fast) ease, color var(--anim-fast) ease, opacity var(--anim-fast) ease;
     }
     .card:hover{transform:translateY(-4px);box-shadow: var(--shadow);}
-    .cardPad{padding:18px}
+    .cardPad{padding:20px}
+    .leadCard.is-highlight{
+      border-color: rgba(242,140,40,.6);
+      box-shadow: 0 0 0 3px rgba(242,140,40,.22), 0 18px 48px rgba(0,0,0,.35);
+    }
     /* Metabolismo (primer bloque): alinear el Permiso Cofepris al mismo nivel en ambas tarjetas */
     main > section:first-of-type .card{display:flex;flex-direction:column}
     main > section:first-of-type .cardPad{display:flex;flex-direction:column;flex:1}
@@ -557,9 +562,9 @@
 
     /* Bigger CTAs (only where applied) */
     .btnXL{
-      padding:16px 18px;
+      padding:18px 20px;
       border-radius:14px;
-      font-size:16px;
+      font-size:17px;
       letter-spacing:.2px;
     }
     @media (max-width:700px){
@@ -586,8 +591,8 @@
       margin-top:14px;
       padding:14px 14px;
       border-radius: 16px;
-      border:1px solid rgba(22,163,74,.20);
-      background: rgba(22,163,74,.08);
+      border:1px solid rgba(11,107,58,.24);
+      background: rgba(11,107,58,.12);
       color: var(--text);
       font-size: 14.5px;
       line-height:1.55;
@@ -650,19 +655,20 @@
       margin-top:12px;
     }
     @media (max-width: 560px){.formGrid{grid-template-columns:1fr}}
-    label{font-size:12px;color: var(--muted); display:block; margin:0 0 6px}
+    label{font-size:13.5px;color: var(--muted); display:block; margin:0 0 8px}
     input{
       width:100%;
-      padding:12px 12px;
-      border-radius: 12px;
+      padding:14px 14px;
+      border-radius: 14px;
       border: 1px solid var(--border);
       background: var(--surface);
       color: var(--text);
       outline:2px solid transparent;
       outline-offset:2px;
+      font-size:16px;
     }
-    input:focus{border-color: var(--cta); box-shadow: 0 0 0 4px rgba(22,163,74,.14)}
-    .formActions{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px}
+    input:focus{border-color: var(--success); box-shadow: 0 0 0 4px rgba(11,107,58,.16)}
+    .formActions{display:flex;gap:12px;flex-wrap:wrap;margin-top:14px}
     .consent{font-size:13.5px;color: rgba(203,213,225,.95);line-height:1.55;margin-top:10px}
 
     /* Test */
@@ -673,38 +679,75 @@
       align-items:stretch;
     }
     @media (max-width: 980px){.testGrid{grid-template-columns:1fr}}
+    .testLockWrap{
+      position:relative;
+    }
+    .testLockOverlay{
+      position:absolute;
+      inset:-10px -10px auto -10px;
+      padding:14px 16px;
+      border-radius:18px;
+      border:1px solid rgba(11,107,58,.35);
+      background: rgba(11,107,58,.2);
+      color:#fff;
+      font-weight:700;
+      font-size:16px;
+      line-height:1.45;
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      gap:12px;
+      box-shadow: 0 18px 40px rgba(11,107,58,.22);
+      z-index:3;
+    }
+    .testLockOverlay span{color:rgba(255,255,255,.9);font-weight:600}
+    .testLockOverlay .btn{
+      padding:10px 14px;
+      border-radius:999px;
+      font-size:14px;
+    }
+    .testLockOverlay.is-hidden{display:none;}
+    .testLocked .check{
+      opacity:.6;
+      pointer-events:none;
+    }
+    .testLocked .miniBtns .btn,
+    .testLocked .formActions .btn{
+      opacity:.6;
+      pointer-events:none;
+    }
     .checkList{display:grid;grid-template-columns:1fr 1fr;gap:10px}
     @media (max-width: 640px){.checkList{grid-template-columns:1fr}}
     .check{
       display:flex;gap:10px;align-items:flex-start;
-      padding:12px 12px;
-      border-radius: 14px;
+      padding:14px 14px;
+      border-radius: 16px;
       border:1px solid var(--border);
       background: var(--surface);
       cursor:pointer;
       user-select:none;
     }
     .check input{width:18px;height:18px;margin-top:2px}
-    .check strong{display:block;font-size:13px}
-    .check span{display:block;color: var(--muted2); font-size:12px; line-height:1.35; margin-top:2px}
+    .check strong{display:block;font-size:15px}
+    .check span{display:block;color: var(--muted2); font-size:13.5px; line-height:1.4; margin-top:4px}
     .resultBox{
       height:100%;
       display:flex;flex-direction:column;gap:10px;
     }
     .score{
       display:flex;align-items:center;justify-content:space-between;gap:10px;
-      padding:14px 14px;border-radius:16px;
+      padding:16px 16px;border-radius:18px;
       border:1px solid var(--border);
       background: var(--surface);
     }
-    .score strong{font-size:14px}
-    .score b{font-size:22px}
+    .score strong{font-size:15px}
+    .score b{font-size:24px}
     .resultText{
-      padding:14px 14px;border-radius:16px;
-      border:1px solid rgba(22,163,74,.22);
-      background: rgba(22,163,74,.08);
+      padding:16px 16px;border-radius:18px;
+      border:1px solid rgba(11,107,58,.26);
+      background: rgba(11,107,58,.12);
       color: var(--text);
-      font-size:13px;line-height:1.45;
+      font-size:15px;line-height:1.55;
       flex:1;
     }
     .miniBtns{display:flex;gap:10px;flex-wrap:wrap}
@@ -720,6 +763,56 @@
       transition: opacity .2s ease, transform .2s ease;
     }
     .toast.on{opacity:1; transform:translateX(-50%) translateY(-6px)}
+
+    .testCard{
+      border-color: rgba(11,107,58,.22);
+      background: linear-gradient(180deg, rgba(15,58,69,.96), rgba(10,38,46,.98));
+    }
+    .testCard .cardPad{padding:22px}
+    .testGate{
+      display:flex;gap:12px;align-items:flex-start;
+      padding:14px 16px;
+      border-radius:16px;
+      border:1px solid rgba(11,107,58,.32);
+      background: rgba(11,107,58,.18);
+      color:#fff;
+      margin-bottom:14px;
+      box-shadow: 0 14px 30px rgba(11,107,58,.18);
+    }
+    .testGate strong{display:block;font-size:15.5px;margin-bottom:4px}
+    .testGate span{color:rgba(255,255,255,.85);font-size:14.5px;line-height:1.5}
+    .testGateIcon{
+      width:42px;height:42px;border-radius:12px;
+      background: rgba(11,107,58,.28);
+      border:1px solid rgba(255,255,255,.25);
+      display:flex;align-items:center;justify-content:center;
+      font-weight:900;
+      color:#fff;
+      flex:0 0 auto;
+    }
+    .resultBox.is-locked .resultText{
+      border-color: rgba(11,107,58,.35);
+      background: rgba(11,107,58,.18);
+    }
+    .shareCard{
+      display:flex;gap:12px;align-items:flex-start;
+      padding:14px 16px;
+      border-radius:16px;
+      border:1px solid rgba(11,107,58,.35);
+      background: rgba(11,107,58,.12);
+      color: var(--text);
+    }
+    .shareCard strong{display:block;font-size:15.5px;margin-bottom:4px}
+    .shareCard p{margin:0;color:rgba(255,255,255,.84);font-size:14.5px;line-height:1.5}
+    .shareIcon{
+      width:42px;height:42px;border-radius:12px;
+      background: rgba(11,107,58,.24);
+      border:1px solid rgba(255,255,255,.2);
+      display:flex;align-items:center;justify-content:center;
+      font-weight:900;
+      color:#fff;
+      flex:0 0 auto;
+    }
 
     /* Bottom */
     .footer{
@@ -760,9 +853,9 @@
       .navLinks{width:100%;justify-content:flex-start;}
     }
     @keyframes ctaPulseOnce{
-      0%{transform:scale(1); box-shadow:0 10px 28px rgba(22,163,74,.26);}
-      50%{transform:scale(1.01); box-shadow:0 16px 40px rgba(22,163,74,.30);}
-      100%{transform:scale(1); box-shadow:0 10px 28px rgba(22,163,74,.26);}
+      0%{transform:scale(1); box-shadow:0 10px 28px rgba(11,107,58,.26);}
+      50%{transform:scale(1.01); box-shadow:0 16px 40px rgba(11,107,58,.30);}
+      100%{transform:scale(1); box-shadow:0 10px 28px rgba(11,107,58,.26);}
     }
     .sticky .btnPrimary.pulse-once{
       animation: ctaPulseOnce 1.2s ease-out 0s 1;
@@ -790,8 +883,8 @@
       inset:-60px -60px auto auto;
       width:260px;height:260px;
       background:
-        radial-gradient(circle at 30% 30%, rgba(22,163,74,.22), transparent 60%),
-        radial-gradient(circle at 60% 70%, rgba(22,163,74,.16), transparent 62%);
+        radial-gradient(circle at 30% 30%, rgba(11,107,58,.22), transparent 60%),
+        radial-gradient(circle at 60% 70%, rgba(11,107,58,.16), transparent 62%);
       pointer-events:none;
       opacity:.95;
     }
@@ -814,14 +907,14 @@
     .trustPoints li{display:flex;gap:10px;align-items:flex-start;color:rgba(71,85,105,.88);font-size:14.5px;line-height:1.55}
     .trustDot{
       width:22px;height:22px;border-radius:8px;
-      background: rgba(22,163,74,.14);
-      border:1px solid rgba(22,163,74,.35);
+      background: rgba(11,107,58,.14);
+      border:1px solid rgba(11,107,58,.35);
       display:flex;align-items:center;justify-content:center;
       flex:0 0 auto;
       margin-top:1px;
       box-shadow: 0 10px 18px rgba(15,23,42,.08);
     }
-    .trustDot svg{width:14px;height:14px;fill:none;stroke:rgba(22,163,74,.95);stroke-width:2}
+    .trustDot svg{width:14px;height:14px;fill:none;stroke:rgba(11,107,58,.95);stroke-width:2}
     .trustActions{display:flex;gap:10px;flex-wrap:wrap;margin-top:14px;position:relative;z-index:1;justify-content:center}
     .trustActionsRow{grid-column:1 / -1; justify-content:center; margin-top:6px;}
     .trustActionsRow .btn{min-width:200px; text-align:center; padding:12px 16px;}
@@ -866,8 +959,8 @@
       border-radius:12px;
       border:1px solid var(--border);
       background:
-        radial-gradient(circle at 20% 18%, rgba(22,163,74,.12), transparent 62%),
-        radial-gradient(circle at 80% 85%, rgba(37,99,235,.10), transparent 62%),
+        radial-gradient(circle at 20% 18%, rgba(11,107,58,.12), transparent 62%),
+        radial-gradient(circle at 80% 85%, rgba(11,43,52,.16), transparent 62%),
         linear-gradient(180deg, #ffffff, var(--surface));
       padding:14px;
       box-sizing:border-box;
@@ -1008,12 +1101,12 @@
       font-weight:900 !important;
       letter-spacing:.2px !important;
     }
-    #confianza .trustActionsRow button:nth-of-type(1){--tab-accent: rgb(37,99,235);}  /* azul */
-    #confianza .trustActionsRow button:nth-of-type(2){--tab-accent: rgb(11,107,58);}  /* verde */
-    #confianza .trustActionsRow button:nth-of-type(3){--tab-accent: rgb(242,140,40);} /* naranja */
-    #confianza .trustActionsRow .btn:nth-of-type(1){--tab-accent: rgb(37,99,235);}  /* azul */
-    #confianza .trustActionsRow .btn:nth-of-type(2){--tab-accent: rgb(11,107,58);}  /* verde */
-    #confianza .trustActionsRow .btn:nth-of-type(3){--tab-accent: rgb(242,140,40);} /* naranja */
+    #confianza .trustActionsRow button:nth-of-type(1){--tab-accent: rgb(11,107,58);}  /* verde */
+    #confianza .trustActionsRow button:nth-of-type(2){--tab-accent: rgb(11,43,52);}  /* azul profundo */
+    #confianza .trustActionsRow button:nth-of-type(3){--tab-accent: rgb(11,107,58);} /* verde */
+    #confianza .trustActionsRow .btn:nth-of-type(1){--tab-accent: rgb(11,107,58);}  /* verde */
+    #confianza .trustActionsRow .btn:nth-of-type(2){--tab-accent: rgb(11,43,52);}  /* azul profundo */
+    #confianza .trustActionsRow .btn:nth-of-type(3){--tab-accent: rgb(11,107,58);} /* verde */
 
     #confianza .trustActionsRow button,
     #confianza .trustActionsRow .btn{
@@ -1089,20 +1182,20 @@
     .pdrRow{display:flex;align-items:center;gap:10px}
     .pdrIcon{
       width:64px;height:64px;border-radius:18px;
-      background: rgba(22,163,74,.18);
-      border:1px solid rgba(22,163,74,.45);
+      background: rgba(11,107,58,.18);
+      border:1px solid rgba(11,107,58,.45);
       display:flex;align-items:center;justify-content:center;
       box-shadow: 0 14px 26px rgba(15,23,42,.12);
       flex:0 0 auto;
     }
     #confianza .pdrIcon{
-      background: rgba(22,163,74,.24);
-      border-color: rgba(22,163,74,.72);
+      background: rgba(11,107,58,.24);
+      border-color: rgba(11,107,58,.72);
       box-shadow:
         0 0 0 1px rgba(11,18,32,.25),
         0 16px 28px rgba(15,23,42,.18);
     }
-    .pdrIcon svg{width:34px;height:34px;fill:none;stroke:rgba(22,163,74,.98);stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
+    .pdrIcon svg{width:34px;height:34px;fill:none;stroke:rgba(11,107,58,.98);stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
     .pdrTxt b{display:block;font-size:20px;letter-spacing:-.2px}
     .pdrTxt span{display:block;margin-top:4px;color:rgba(71,85,105,.9);font-size:14px;line-height:1.35}
     .pdrTxt em{display:block;margin-top:6px;color:rgba(71,85,105,.78);font-size:12.5px;font-style:normal;line-height:1.35}
@@ -1129,12 +1222,12 @@
     }
     .certIcon{
       width:32px;height:32px;border-radius:12px;
-      background: rgba(22,163,74,.12);
-      border:1px solid rgba(22,163,74,.32);
+      background: rgba(11,107,58,.12);
+      border:1px solid rgba(11,107,58,.32);
       display:flex;align-items:center;justify-content:center;
       flex:0 0 auto;
     }
-    .certIcon svg{width:18px;height:18px;fill:none;stroke:rgba(22,163,74,.95);stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
+    .certIcon svg{width:18px;height:18px;fill:none;stroke:rgba(11,107,58,.95);stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
     .certTxt strong{display:block;font-size:11.5px;line-height:1.05;color:var(--text)}
     .certTxt span{display:block;margin-top:2px;font-size:10.5px;line-height:1.15;color:rgba(71,85,105,.72)}
 
@@ -1191,8 +1284,8 @@
     /* Garantía */
     .guaranteeCard{
       margin-top:14px;
-      background: linear-gradient(135deg, rgba(22,163,74,.10), rgba(37,99,235,.06));
-      border:1px solid rgba(22,163,74,.22);
+      background: linear-gradient(135deg, rgba(11,107,58,.12), rgba(11,43,52,.08));
+      border:1px solid rgba(11,107,58,.24);
     }
     .guaranteePad{display:flex;align-items:center;justify-content:space-between;gap:14px;flex-wrap:wrap}
     .guaranteeTitle{font-size:18px;margin:0 0 4px}
@@ -1283,8 +1376,8 @@
 :where(.segmented,.tabsRow,.topTabs,.tabs,.pillRow,.sectionTabs) :where(button,a){
   position:relative;
   border-radius:999px;
-  border:1px solid rgba(120,160,255,.28);
-  background: rgba(10,18,28,.55);
+  border:1px solid rgba(11,107,58,.28);
+  background: rgba(11,43,52,.58);
   color: rgba(245,250,255,.92);
   padding:12px 18px;
   box-shadow: 0 10px 28px rgba(0,0,0,.28);
@@ -1293,28 +1386,28 @@
 
 :where(.segmented,.tabsRow,.topTabs,.tabs,.pillRow,.sectionTabs) :where(button,a):hover{
   transform: translateY(-1px);
-  border-color: rgba(120,200,255,.55);
+  border-color: rgba(11,107,58,.55);
   box-shadow: 0 14px 34px rgba(0,0,0,.34);
 }
 
 /* Estado activo (soporta varias implementaciones comunes) */
 :where(.segmented,.tabsRow,.topTabs,.tabs,.pillRow,.sectionTabs) :where(.active,[aria-selected="true"],[data-active="true"]){
-  border-color: rgba(120,240,255,.75);
-  box-shadow: 0 0 0 3px rgba(70,200,255,.16), 0 16px 40px rgba(0,0,0,.38);
+  border-color: rgba(11,107,58,.75);
+  box-shadow: 0 0 0 3px rgba(11,107,58,.18), 0 16px 40px rgba(0,0,0,.38);
 }
 
 /* 2) Cards (PDR / Certificaciones): más “premium” sin perder seriedad */
 :where(.card,.tile,.panel){
   border-radius:18px;
-  border:1px solid rgba(120,160,255,.22);
-  background: radial-gradient(120% 120% at 20% 0%, rgba(90,170,255,.10), rgba(0,0,0,0)) , rgba(10,18,28,.50);
+  border:1px solid rgba(11,107,58,.22);
+  background: radial-gradient(120% 120% at 20% 0%, rgba(11,107,58,.10), rgba(0,0,0,0)) , rgba(11,43,52,.55);
   box-shadow: 0 14px 40px rgba(0,0,0,.32);
   transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease;
 }
 
 :where(.card,.tile,.panel):hover{
   transform: translateY(-2px);
-  border-color: rgba(120,240,255,.42);
+  border-color: rgba(11,107,58,.42);
   box-shadow: 0 18px 54px rgba(0,0,0,.38);
 }
 
@@ -1354,8 +1447,8 @@
   inset:-35% -60%;
   background: linear-gradient(120deg,
     transparent 0%,
-    rgba(242,140,40,.18) 35%,
-    rgba(11,107,58,.14) 52%,
+    rgba(11,107,58,.22) 35%,
+    rgba(11,43,52,.18) 52%,
     transparent 68%);
   filter: blur(8px);
   pointer-events:none;
@@ -1402,33 +1495,33 @@
 
 /* ====== Tabs superiores: a.btn.btnGhost ====== */
 a.btn.btnGhost{
-  border:1px solid rgba(120,240,255,.62) !important;
-  background: rgba(10,18,28,.50) !important;
+  border:1px solid rgba(11,107,58,.55) !important;
+  background: rgba(11,43,52,.55) !important;
   border-radius: 999px !important;
   padding: 14px 22px !important;
-  box-shadow: 0 0 0 2px rgba(70,200,255,.12), 0 14px 34px rgba(0,0,0,.38) !important;
+  box-shadow: 0 0 0 2px rgba(11,107,58,.16), 0 14px 34px rgba(0,0,0,.38) !important;
   transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease, background .18s ease !important;
 }
 
 a.btn.btnGhost:hover{
   transform: translateY(-1px) !important;
-  border-color: rgba(120,240,255,.92) !important;
-  background: rgba(10,18,28,.58) !important;
-  box-shadow: 0 0 0 3px rgba(70,200,255,.18), 0 18px 44px rgba(0,0,0,.44) !important;
+  border-color: rgba(11,107,58,.85) !important;
+  background: rgba(11,43,52,.65) !important;
+  box-shadow: 0 0 0 3px rgba(11,107,58,.22), 0 18px 44px rgba(0,0,0,.44) !important;
 }
 
 a.btn.btnGhost:focus-visible{
   outline: none !important;
-  box-shadow: 0 0 0 4px rgba(70,200,255,.26), 0 18px 44px rgba(0,0,0,.44) !important;
+  box-shadow: 0 0 0 4px rgba(11,107,58,.26), 0 18px 44px rgba(0,0,0,.44) !important;
 }
 
 /* ====== Cards documentación: a.card.trustTile ====== */
 a.card.trustTile{
   border-radius: 22px !important;
-  border: 1px solid rgba(120,240,255,.22) !important;
+  border: 1px solid rgba(11,107,58,.22) !important;
   background:
-    radial-gradient(120% 120% at 18% 0%, rgba(90,170,255,.16), rgba(0,0,0,0)),
-    rgba(10,18,28,.52) !important;
+    radial-gradient(120% 120% at 18% 0%, rgba(11,107,58,.16), rgba(0,0,0,0)),
+    rgba(11,43,52,.55) !important;
   box-shadow: 0 18px 56px rgba(0,0,0,.42) !important;
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
@@ -1437,15 +1530,15 @@ a.card.trustTile{
 
 a.card.trustTile:hover{
   transform: translateY(-2px) !important;
-  border-color: rgba(120,240,255,.45) !important;
+  border-color: rgba(11,107,58,.45) !important;
   box-shadow: 0 22px 70px rgba(0,0,0,.48) !important;
 }
 
 /* Panel interno dentro del card (donde dice “Click para abrir”) */
 a.card.trustTile .trustBoard{
   border-radius: 18px !important;
-  border: 1px solid rgba(120,240,255,.14) !important;
-  background: rgba(255,255,255,.03) !important;
+  border: 1px solid rgba(11,107,58,.18) !important;
+  background: rgba(255,255,255,.04) !important;
 }
 
 /* Título más visible sin perder seriedad */
@@ -1470,7 +1563,7 @@ a.card.trustTile h4{
 
 a.card.trustTile .trustBoard{
   background: rgba(255,255,255,.06) !important;
-  border-color: rgba(160,230,255,.22) !important;
+  border-color: rgba(127,227,179,.22) !important;
 }
 
 /* Texto principal del bloque PDR (lo que ahora no se lee) */
@@ -1490,7 +1583,7 @@ a.card.trustTile .trustBoard *{
 a.card.trustTile hr,
 a.card.trustTile .divider,
 a.card.trustTile .line{
-  border-color: rgba(160,230,255,.18) !important;
+  border-color: rgba(127,227,179,.18) !important;
   opacity: 1 !important;
 }
 </style>
@@ -1501,7 +1594,7 @@ a.card.trustTile .line{
 a.card.trustTile .trustBoard.pdrBoard,
 a.card.trustTile .pdrBoard{
   background: rgba(255,255,255,.08) !important;
-  border-color: rgba(160,230,255,.26) !important;
+  border-color: rgba(127,227,179,.26) !important;
   opacity: 1 !important;
   filter: none !important;
   mix-blend-mode: normal !important;
@@ -1528,7 +1621,7 @@ a.card.trustTile .trustBoard.pdrBoard .dash,
 a.card.trustTile .pdrBoard .dash,
 a.card.trustTile .trustBoard.pdrBoard hr,
 a.card.trustTile .pdrBoard hr{
-  border-color: rgba(160,230,255,.22) !important;
+  border-color: rgba(127,227,179,.22) !important;
   opacity: 1 !important;
 }
 </style>
@@ -1584,7 +1677,7 @@ a.card.trustTile .trustBoard *{
 a.card.trustTile .trustBoard.pdrBoard,
 a.card.trustTile .pdrBoard{
   background: rgba(255,255,255,.09) !important;
-  border-color: rgba(160,230,255,.26) !important;
+  border-color: rgba(127,227,179,.26) !important;
 }
 </style>
 
@@ -1659,7 +1752,7 @@ a.card.trustTile .pdrBoard{
             <div class="bullet">Contenido educativo para que entiendas tu metabolismo.</div>
           </div>
 
-              <div class="card" style="margin-top:12px">
+              <div class="card leadCard" id="leadCard" style="margin-top:12px">
                 <div class="cardPad">
                   <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:14px;flex-wrap:wrap">
                     <div>
@@ -1738,8 +1831,8 @@ a.card.trustTile .pdrBoard{
             <div class="videoCaption">
               <strong>“Monterrey… esto se levanta con estructura.”</strong>
               <span>
-                Reemplaza este video con el tuyo (Rafael) para que la página venda sola.
-                Abajo te dejo el texto sugerido.
+                Inserta tu video vertical para que la página comunique confianza desde el primer segundo.
+                Abajo tienes un guion breve sugerido.
               </span>
             </div>
           </div>
@@ -1751,7 +1844,7 @@ a.card.trustTile .pdrBoard{
             Este es un testimonio real de alguien que pasó de sentirse estancado a recuperar estructura, energía y motivación con el sistema Feel Great (Unici-Té + Balance).
             Si te identificas con falta de impulso, antojos o bajones, este video te puede hacer sentido.
           </p>
-          <p style="margin:8px 0 0;color:rgba(71,85,105,.9);font-weight:700;font-size:13.5px">Siguiente paso: escribe METABOLISMO y te guiamos.</p>
+          <p style="margin:8px 0 0;color:rgba(71,85,105,.9);font-weight:700;font-size:13.5px">Siguiente paso: escribe METABOLISMO y te guiamos con claridad.</p>
           <p style="margin:6px 0 0;color:rgba(71,85,105,.65);font-size:12px;line-height:1.45">Testimonio individual. Resultados varían. Contenido educativo.</p>
         </div>
       </div>
@@ -1860,9 +1953,22 @@ a.card.trustTile .pdrBoard{
           <p>Marca lo que te pasa con frecuencia. No es diagnóstico: es una guía para conversar y decidir tu siguiente paso.</p>
         </div>
 
-        <div class="testGrid">
-          <div class="card">
+        <div class="testLockWrap" id="testLockWrap">
+          <div class="testLockOverlay" id="testLockOverlay">
+            🔒 <span>Para ver tu resultado y usar el test, completa Nombre y Email (1 minuto).</span>
+            <button class="btn btnPrimary" type="button" id="unlockTestBtn">Desbloquear test</button>
+          </div>
+
+          <div class="testGrid" id="testGrid">
+          <div class="card testCard">
             <div class="cardPad">
+              <div class="testGate">
+                <div class="testGateIcon">🔒</div>
+                <div>
+                  <strong>Desbloquea tu resultado final</strong>
+                  <span>Completa tu Nombre y Email en el formulario de arriba. Luego vuelve y obtén tu lectura educativa.</span>
+                </div>
+              </div>
               <div class="checkList" id="checkList">
                 <!-- checks injected by JS -->
               </div>
@@ -1879,19 +1985,26 @@ a.card.trustTile .pdrBoard{
             </div>
           </div>
 
-          <div class="card">
-            <div class="cardPad resultBox">
+          <div class="card testCard">
+            <div class="cardPad resultBox is-locked">
               <div class="score">
                 <strong>Tu puntuación</strong>
                 <b id="scoreNum">0</b>
               </div>
               <div style="width:100%;background:var(--surface);border-radius:999px;height:8px;overflow:hidden;margin-top:6px;border:1px solid var(--border)">
-                <div id="scoreBar" style="height:100%;width:0%;background:var(--cta);transition:width .18s ease"></div>
+                <div id="scoreBar" style="height:100%;width:0%;background:var(--success);transition:width .18s ease"></div>
               </div>
 
               <div class="resultText" id="resultText">
-                Marca tus señales y dale a “Ver mi resultado”.
-                Te diré qué significa a nivel educativo y el siguiente paso recomendado.
+                Para ver tu resultado y usar el test, completa Nombre y Email (1 minuto).
+              </div>
+
+              <div class="shareCard">
+                <div class="shareIcon">👥</div>
+                <div>
+                  <strong>Compártelo con 1 amigo</strong>
+                  <p>Enviar tu resultado ayuda a alguien cercano a tomar acción y buscar guía.</p>
+                </div>
               </div>
 
               <div class="miniBtns">
@@ -1904,6 +2017,7 @@ a.card.trustTile .pdrBoard{
               </p>
             </div>
           </div>
+        </div>
         </div>
 
       </div>
@@ -1973,9 +2087,9 @@ a.card.trustTile .pdrBoard{
             </a>
 
             <div class="trustActions trustActionsRow">
-              <a class="btn btnGhost" href="https://www.unicityscience.org/clinical-validation-studies/?lang=es" target="_blank" rel="noopener noreferrer" style="border:2px solid #2DD4BF !important;">Ciencia de Unicity</a>
-              <a class="btn btnGhost" href="https://www.unicity.com/mex/es/learn/history" target="_blank" rel="noopener noreferrer" style="border:2px solid #2DD4BF !important;">Historia de Unicity</a>
-              <a class="btn btnGhost" href="https://www.unicity.com/usa/es/opportunity" target="_blank" rel="noopener noreferrer" style="border:2px solid #2DD4BF !important;">Oportunidad de negocio</a>
+              <a class="btn btnGhost" href="https://www.unicityscience.org/clinical-validation-studies/?lang=es" target="_blank" rel="noopener noreferrer" style="border:2px solid #0B6B3A !important;">Ciencia de Unicity</a>
+              <a class="btn btnGhost" href="https://www.unicity.com/mex/es/learn/history" target="_blank" rel="noopener noreferrer" style="border:2px solid #0B6B3A !important;">Historia de Unicity</a>
+              <a class="btn btnGhost" href="https://www.unicity.com/usa/es/opportunity" target="_blank" rel="noopener noreferrer" style="border:2px solid #0B6B3A !important;">Oportunidad de negocio</a>
             </div>
 
               <a class="card trustTile" href="https://www.pdr.net/full-prescribing-information/hl/?druglabelid=24170" target="_blank" rel="noopener" aria-label="Abrir evidencia PDR">
@@ -2308,8 +2422,10 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
       {k:"ansiedad", t:"Ansiedad por comida o por la noche", d:"Inquietud que se calma comiendo."}
     ];
 
+    const LEAD_KEY = "bn_lead";
     let lastResultText = "";
     let lastScore = 0;
+    let leadSubmitted = false;
 
     function toast(msg){
       const el = document.getElementById("toast");
@@ -2454,6 +2570,20 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
         return;
       }
 
+      const leadPayload = { name: data.name || "", email: data.email || "", ts: new Date().toISOString() };
+      if(!isLeadValid(leadPayload)){
+        setLeadStatus("Completa nombre y email válidos", true);
+        toast("Completa nombre y email válidos");
+        return;
+      }
+
+      try{
+        localStorage.setItem(LEAD_KEY, JSON.stringify(leadPayload));
+      }catch(_){}
+      leadSubmitted = true;
+      setResultLockState(false);
+      setTestLockedState(false);
+
       setLeadStatus("Guardando…", false);
       setSubmitState("loading");
 
@@ -2474,6 +2604,8 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
       setLeadStatus("Gracias, recibido", false);
       setSubmitState("success");
       toast("Gracias, recibido");
+      leadSubmitted = true;
+      setResultLockState(false);
       try{ window.dataLayer.push({event:"lead_submit_success"}); }catch(_){}
       try{ window.dataLayer.push({event:"submit_lead"}); }catch(_){}
 
@@ -2511,6 +2643,7 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
     }
 
     function computeTest(){
+      if(!requireLeadForResult()){ return; }
       const checks = Array.from(document.querySelectorAll('#checkList input[type="checkbox"]'));
       const score = checks.filter(c=>c.checked).length;
       lastScore = score;
@@ -2535,6 +2668,10 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
         msg += `\n\nSugerencia: consulta a tu médico general y pregunta por evaluación con glucosa e insulina en ayunas (y HbA1c; HOMA‑IR si aplica), según tu caso.`;
       }
 
+      const firstName = getLeadFirstName();
+      if(firstName){
+        msg = `Hola, ${firstName} 👋\n\n${msg}`;
+      }
       msg += "\n\nSi quieres guía paso a paso con Unici-Té + Balance, escribe METABOLISMO y te acompañamos.";
       lastResultText = `Resultado: ${level}. Puntuación: ${score}.\n${msg}`;
 
@@ -2547,11 +2684,16 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
       Array.from(document.querySelectorAll('#checkList input[type="checkbox"]')).forEach(c=>c.checked=false);
       lastScore = 0; lastResultText = "";
       document.getElementById("scoreNum").textContent = "0";
-      document.getElementById("resultText").textContent = "Marca tus señales y dale a “Ver mi resultado”. Te diré qué significa a nivel educativo y el siguiente paso recomendado.";
+      if(leadSubmitted){
+        document.getElementById("resultText").textContent = "Marca tus señales y dale a “Ver mi resultado”. Te diré qué significa a nivel educativo y el siguiente paso recomendado.";
+      }else{
+        document.getElementById("resultText").textContent = "Para ver tu resultado y usar el test, completa Nombre y Email (1 minuto).";
+      }
       toast("Listo");
     }
 
     function sendResultToWhatsApp(){
+      if(!requireLeadForResult()){ return; }
       if(!lastResultText){
         computeTest();
       }
@@ -2559,20 +2701,132 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
     }
 
     async function shareResult(){
+      if(!requireLeadForResult()){ return; }
       const text = lastResultText || (CONFIG.DEFAULT_MESSAGE + " — Bariátrica Natural Monterrey");
-      const shareData = { title: "Bariátrica Natural", text, url: window.location.href };
+      const shareUrl = buildShareUrl();
+      const shareData = { title: "Bariátrica Natural", text, url: shareUrl };
       try{
         if(navigator.share){
           await navigator.share(shareData);
         }else{
-          await navigator.clipboard.writeText(text + "\n" + window.location.href);
-          toast("Copiado");
+          await navigator.clipboard.writeText(shareUrl);
+          toast("Enlace copiado para compartir");
         }
       }catch(e){
         try{
-          await navigator.clipboard.writeText(text + "\n" + window.location.href);
-          toast("Copiado");
+          await navigator.clipboard.writeText(shareUrl);
+          toast("Enlace copiado para compartir");
         }catch(_){}
+      }
+    }
+
+    function buildShareUrl(){
+      const url = new URL(window.location.href);
+      url.searchParams.set("share", "1");
+      url.hash = "test";
+      return url.toString();
+    }
+
+    function setResultLockState(isLocked){
+      const box = document.querySelector(".resultBox");
+      if(!box) return;
+      box.classList.toggle("is-locked", isLocked);
+    }
+
+    function setTestLockedState(isLocked){
+      const wrap = document.getElementById("testLockWrap");
+      const overlay = document.getElementById("testLockOverlay");
+      const buttons = document.querySelectorAll('#testGrid .btn');
+      const checks = document.querySelectorAll('#checkList input[type="checkbox"]');
+      if(wrap){ wrap.classList.toggle("testLocked", isLocked); }
+      if(overlay){ overlay.classList.toggle("is-hidden", !isLocked); }
+      checks.forEach(c=>{ c.disabled = isLocked; });
+      buttons.forEach(btn=>{
+        btn.disabled = isLocked;
+        btn.setAttribute("aria-disabled", isLocked ? "true" : "false");
+      });
+    }
+
+    function getLeadFirstName(){
+      try{
+        const raw = (getStoredLead()?.name || "").trim();
+        if(!raw){ return ""; }
+        return raw.split(/\s+/)[0];
+      }catch(_){ return ""; }
+    }
+
+    function isLeadValid(lead){
+      if(!lead) return false;
+      const nameOk = (lead.name || "").trim().length >= 2;
+      const emailOk = /@/.test(lead.email || "") && /\./.test(lead.email || "");
+      return nameOk && emailOk;
+    }
+
+    function tryUnlockLeadFromForm(notify){
+      const nameField = document.getElementById("name");
+      const emailField = document.getElementById("email");
+      const leadPayload = {
+        name: nameField ? nameField.value.trim() : "",
+        email: emailField ? emailField.value.trim() : "",
+        ts: new Date().toISOString()
+      };
+      if(!isLeadValid(leadPayload)){
+        if(notify){
+          setLeadStatus("Completa nombre y email válidos", true);
+          toast("Completa nombre y email válidos");
+        }
+        return false;
+      }
+      try{
+        localStorage.setItem(LEAD_KEY, JSON.stringify(leadPayload));
+      }catch(_){}
+      leadSubmitted = true;
+      setResultLockState(false);
+      setTestLockedState(false);
+      return true;
+    }
+
+    function getStoredLead(){
+      try{
+        const raw = localStorage.getItem(LEAD_KEY);
+        if(!raw) return null;
+        return JSON.parse(raw);
+      }catch(_){
+        return null;
+      }
+    }
+
+    function requireLeadForResult(){
+      if(leadSubmitted){
+        setResultLockState(false);
+        setTestLockedState(false);
+        return true;
+      }
+      if(tryUnlockLeadFromForm(false)){
+        return true;
+      }
+      setResultLockState(true);
+      setTestLockedState(true);
+      const resultText = document.getElementById("resultText");
+      if(resultText){
+        resultText.textContent = "Para ver tu resultado y usar el test, completa Nombre y Email (1 minuto).";
+      }
+      toast("Completa tus datos para ver el resultado");
+      openLeadForm();
+      return false;
+    }
+
+    function openLeadForm(){
+      const form = document.getElementById("leadForm");
+      if(form){ form.scrollIntoView({behavior:"smooth", block:"center"}); }
+      const leadCard = document.getElementById("leadCard");
+      if(leadCard){
+        leadCard.classList.add("is-highlight");
+        setTimeout(()=> leadCard.classList.remove("is-highlight"), 2000);
+      }
+      const nameField = document.getElementById("name");
+      if(nameField && typeof nameField.focus === "function"){
+        nameField.focus({preventScroll:true});
       }
     }
 
@@ -2730,12 +2984,49 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
     }
 
     captureUTMs();
+    try{
+      leadSubmitted = isLeadValid(getStoredLead());
+    }catch(_){
+      leadSubmitted = false;
+    }
     initHeroVideo();
 
     initAnimations();
     initGuaranteeModal();
     initScrollDepth();
     renderTest();
+    setResultLockState(!leadSubmitted);
+    setTestLockedState(!leadSubmitted);
+
+    const _testWrap = document.getElementById("testLockWrap");
+    if(_testWrap){
+      _testWrap.addEventListener("click", (e)=>{
+        if(leadSubmitted){ return; }
+        e.preventDefault();
+        openLeadForm();
+      });
+    }
+
+    const _unlockBtn = document.getElementById("unlockTestBtn");
+    if(_unlockBtn){
+      _unlockBtn.addEventListener("click", (e)=>{
+        if(leadSubmitted){ return; }
+        e.preventDefault();
+        e.stopPropagation();
+        if(!tryUnlockLeadFromForm(true)){
+          openLeadForm();
+        }
+      });
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    if(params.get("share") === "1"){
+      scrollToId("test");
+      if(!leadSubmitted){
+        setResultLockState(true);
+        setTestLockedState(true);
+      }
+    }
 
     (function pulseStickyCTAOnce(){
       if(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches){ return; }


### PR DESCRIPTION
### Motivation
- Garantizar que el Test Metabólico quede bloqueado hasta capturar un lead mínimo (Nombre + Email) antes de permitir marcar checks, ver o compartir resultados.
- Mantener los botones de WhatsApp existentes sin eliminarlos, sólo deshabilitándolos mientras el test esté bloqueado.
- Permitir viralidad controlada: el botón “Compartir” construye un enlace que abre el test pero mantiene el bloqueo hasta capturar el lead.
- Personalizar el resultado para saludar por el primer nombre sin mostrar email/telefono.

### Description
- Cambios en `landing_venta.html` únicamente: introducción de `LEAD_KEY = "bn_lead"`, almacenamiento del lead mínimo en `localStorage` y funciones nuevas/ajustadas: `isLeadValid`, `getStoredLead`, `getLeadFirstName`, `tryUnlockLeadFromForm`, `requireLeadForResult`, `setTestLockedState`, `setResultLockState`, `buildShareUrl` y `openLeadForm` (resalta el formulario con `.leadCard.is-highlight`).
- Añadido overlay visual y botón `Desbloquear test` encima del bloque del Test que desactiva checkboxes y botones hasta validar/guardar el lead; los checks y botones se deshabilitan mediante `setTestLockedState` y se reactivan al guardar `bn_lead` válido.
- Flujo de compartir: `shareResult` ahora usa `buildShareUrl()` que añade `?share=1` y `#test` al link; al abrir con `share=1` la página hace scroll al test pero mantiene el bloqueo hasta capturar Nombre+Email.
- Ajustes UX: el resultado ahora inicia con `Hola, {Nombre} 👋` usando `getLeadFirstName`, se actualizó copy del overlay/resultados, se añadió estilo `.leadCard.is-highlight` y pequeños cambios visuales en el área del test; se reusa el formulario existente y se valida nombre >=2 chars y email básico.

### Testing
- Se levantó un servidor local con `python -m http.server 8000` y la página fue servida correctamente (server iniciado).
- Se intentó ejecutar un script Playwright para abrir `landing_venta.html?share=1#test` y generar `artifacts/landing-venta-test-lock.png`, pero la ejecución falló por un crash del navegador (SIGSEGV), por lo que la captura automática no se produjo.
- Los cambios son front-end en `landing_venta.html` y no afectan tests backend/unitarios, por lo que no se ejecutaron suites de backend ni unitarias automáticas.
- Aplicados y verificados los cambios estáticos en el archivo (parches aplicados y commit realizado).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961749f9ea883258f3768b444b1bfdd)