### PR TITLE
Add MX buy-link override for two CTA texts in landing_venta.html

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -3264,5 +3264,44 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
       }
     })();
   </script>
+  <!-- BUY-LINK OVERRIDE (MX) -->
+  <script>
+  (function () {
+    var BUY_URL = "https://ufeelgreat.com/mex/es/product/feel-great?focus=true&sku=36279";
+
+    function norm(s) {
+      return (s || "").replace(/\s+/g, " ").trim().toLowerCase();
+    }
+
+    function isTargetText(txt) {
+      var t = norm(txt);
+      return (t === "comprar el sistema" || t === "comprar ahora");
+    }
+
+    // 1) Enlaces <a> (solo los 2 CTAs por texto)
+    var links = document.querySelectorAll("a");
+    for (var i = 0; i < links.length; i++) {
+      var a = links[i];
+      var tA = a.textContent || "";
+      if (isTargetText(tA)) {
+        a.setAttribute("href", BUY_URL);
+        a.setAttribute("target", "_blank");
+        a.setAttribute("rel", "noopener noreferrer");
+      }
+    }
+
+    // 2) Botones <button> (solo los 2 CTAs por texto)
+    var btns = document.querySelectorAll("button");
+    for (var j = 0; j < btns.length; j++) {
+      var b = btns[j];
+      var tB = b.textContent || "";
+      if (isTargetText(tB)) {
+        b.onclick = function () { window.open(BUY_URL, "_blank", "noopener"); };
+        b.style.cursor = "pointer";
+      }
+    }
+  })();
+  </script>
+  <!-- /BUY-LINK OVERRIDE (MX) -->
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Ensure only the two specified CTA elements open the Mexico product URL without changing any UI/UX, copy, styles or other links.

### Description
- Inserted an ES5 self-invoking script block into `landing_venta.html` that normalizes visible text and updates `<a>` elements (`href`, `target`, `rel`) and assigns `onclick` to `<button>` elements when their visible text exactly matches `"Comprar el sistema"` or `"Comprar ahora"`, pointing them to `https://ufeelgreat.com/mex/es/product/feel-great?focus=true&sku=36279` and leaving all other links untouched.

### Testing
- Validated with `git diff --stat`, which shows only `landing_venta.html` was modified (39 insertions) and no other files were changed; no automated unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967b94da3cc8325a0f266f0454b0c4d)