### PR TITLE
Improve guarantee card text contrast

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1330,8 +1330,8 @@
       border:1px solid rgba(11,107,58,.24);
     }
     .guaranteePad{display:flex;align-items:center;justify-content:space-between;gap:14px;flex-wrap:wrap}
-    .guaranteeTitle{font-size:18px;margin:0 0 4px}
-    .guaranteeSub{margin:0;color:rgba(71,85,105,.9);line-height:1.5}
+    .guaranteeTitle{font-size:18px;margin:0 0 4px;color:#F8FAFC}
+    .guaranteeSub{margin:0;color:rgba(226,232,240,.92);line-height:1.5}
     @media (max-width:640px){
       .guaranteePad{align-items:flex-start}
       .guaranteeTitle{font-size:17px}
@@ -1343,10 +1343,15 @@
       color: rgba(248,250,252,.96);
     }
     .guaranteeCard .guaranteeSub{
-      color: rgba(226,232,240,.86);
+      color: rgba(226,232,240,.92);
     }
     .guaranteeCard .fine{
-      color: rgba(226,232,240,.7);
+      color: rgba(226,232,240,.78);
+    }
+    .guaranteeCard .btnGhost{
+      color:#F8FAFC;
+      border-color: rgba(248,250,252,.6);
+      background: rgba(15,23,42,.25);
     }
     /* Garantía modal */
     .gOverlay{


### PR DESCRIPTION
### Motivation

- Fix legibility of the “Garantía de satisfacción 90 días” card text so it reads clearly over the existing background while preserving the current visual structure.  
- Make a minimal change limited to `landing_venta.html`, only touching styles for the guarantee card and the card button, and without modifying JS, links, structure, or global color variables.

### Description

- Set `.guaranteeTitle` color to `#F8FAFC` to ensure the title is high-contrast against the card background.  
- Increase contrast for `.guaranteeSub` by updating its color to `rgba(226,232,240,.92)` and its variant under `.guaranteeCard .guaranteeSub` to the same value.  
- Tighten `.guaranteeCard .fine` contrast by changing it to `rgba(226,232,240,.78)`.  
- Add `.guaranteeCard .btnGhost` styles to improve the button contrast by setting `color`, `border-color`, and a subtle `background` without altering global variables or structure.

### Testing

- Rendered the updated static page with a headless browser and captured a screenshot of `#comprar` showing the guarantee card, and the screenshot capture completed successfully (`artifacts/garantia-card.png`).  
- No automated unit tests were applicable for this purely static/CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690f4223408325ac037c28bcc79220)