### PR TITLE
Move Opción 2 into #comprar right column and update copy

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -2299,15 +2299,14 @@ a.card.trustTile .pdrBoard{
             </div>
           </div>
 
-
-
-                    <div class="card">
+          <div class="card">
             <div class="cardPad">
               <h3 style="margin:0 0 8px;font-size:18px">Opción 2: Quiero emprender (Equipo Fundador)</h3>
               <p style="margin:0;color:rgba(71,85,105,.85);font-size:14px;line-height:1.55">
-Si quieres emprender con una <strong>compañía global</strong> y construir una <strong>fuente de ingreso adicional</strong> con un sistema duplicable — con o sin experiencia — puedes aplicar para ser parte del <strong>Equipo Fundador</strong> en Monterrey.
-                Te damos <strong>entrenamiento, acompañamiento y comunidad</strong>: estructura, impulso y método para arrancar con claridad.
-                Escríbenos por <strong>WhatsApp</strong> y te enviamos el plan de inicio y requisitos.
+                Si hoy sientes que trabajas mucho y avanzas poco… no es falta de capacidad: es falta de estructura.
+                Esto nace en Monterrey, pero es un movimiento para todo México: comunidad, entrenamiento y acompañamiento para construir un plan real, paso a paso.
+                No necesitas experiencia. Necesitas decisión, consistencia y un sistema duplicable.
+                Si quieres que 2026 no se parezca a 2025, este es tu momento: aplica o pide la info por WhatsApp y te enviamos el plan de inicio.
               </p>
               <div class="formActions" style="margin-top:14px">
                 <a class="btn btnGhost" href="https://enrollment.unicity.com/c/LaSaludesRiqueza" target="_blank" rel="noopener" onclick="trackFounder(event)">Aplicar al Equipo Fundador</a>
@@ -2318,7 +2317,7 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
               </p>
             </div>
           </div>
-          </div>
+        </div>
         </div>
 
         <div class="footer">


### PR DESCRIPTION
### Motivation
- Ensure the `#comprar` section shows two cards side-by-side with “Opción 1” left and “Opción 2” right and update the entrepreneurial card copy to the Mexico-wide messaging (Monterrey → todo México). 
- Preserve all existing guarantee styling by reverting any prior CSS tweaks so guarantee rules remain unchanged.

### Description
- Moved the "Opción 2" card markup into the second column of the `#comprar .grid2` by editing `landing_venta.html` so both option cards render side-by-side. 
- Replaced only the descriptive paragraph for "Opción 2" with the new Mexico-wide copy while keeping buttons, links and onclick handlers unchanged. 
- Did not modify any CSS files or guarantee rule definitions; guarantee styling remains as before and only HTML/structure and the `Opción 2` `<p>` were touched.

### Testing
- Launched a static server with `python -m http.server 8000` and rendered the page with headless Chromium via Playwright, producing a screenshot at `artifacts/comprar-opciones.png`, which completed successfully. 
- No automated unit tests were applicable for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690f4223408325ac037c28bcc79220)