### PR TITLE
Fix comprar section grid nesting (restores 2-column layout)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -2323,7 +2323,6 @@ a.card.trustTile .pdrBoard{
             </div>
           </div>
         </div>
-        </div>
 
         <div class="footer">
           <div class="footerInner">


### PR DESCRIPTION
### Motivation
- The second card ("Opción 2") was rendering full-width because an extra closing `</div>` caused it to fall outside the `.grid2` container, breaking the intended two-column layout in `#comprar`.

### Description
- Remove the stray closing `</div>` in the `#comprar` section so `.grid2` now contains exactly two direct `.card` siblings and no other changes were made to copy, links, JS, CSS, or breakpoints.

### Testing
- Verified the change with file diff and line inspections using `nl`, `sed` and `rg` to confirm the extra `</div>` was removed and the `#comprar` structure is correctly nested (succeeded); attempted a Playwright screenshot to visually validate the layout which timed out (failed), and a quick `bs4` parse attempt failed due to the environment missing `beautifulsoup4` (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69691977e0e48325b6925f9e43160af6)