### PR TITLE
Fix #comprar nesting so Opción 2 is second .card in .grid2

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1953,7 +1953,6 @@ a.card.trustTile .pdrBoard{
               </div>
             </div>
           </div>
-
           <div class="card">
             <div class="productMedia"><img src="assets/balance_front.png" alt="Balance" width="950" height="600" /></div>
             <div class="cardPad">
@@ -2292,7 +2291,7 @@ a.card.trustTile .pdrBoard{
               <p class="fine" style="margin-top:12px">Si prefieres, escríbenos por WhatsApp y te guiamos para escoger la opción correcta.</p>
               <div class="formActions" style="margin-top:14px">
                 <button class="btn btnPrimary btnXL" id="cta-buy-now-mx" type="button" onclick="openPurchase()">Comprar ahora</button>
-                <button class="btn btnSecondary" type="button" onclick="window.open('https://wa.me/17872321516?text=OPORTUNIDAD%20DE%20NEGOCIO%20%E2%80%94%20M%C3%89XICO%0AQuiero%20informaci%C3%B3n%20del%20Equipo%20Fundador.','_blank','noopener')
+                <button class="btn btnSecondary" type="button" onclick="window.open('https://wa.me/17872321516?text=OPORTUNIDAD%20DE%20NEGOCIO%20%E2%80%94%20M%C3%89XICO%0AQuiero%20informaci%C3%B3n%20del%20Equipo%20Fundador.','_blank','noopener')"
 >WhatsApp</button>
               </div>
 


### PR DESCRIPTION
### Motivation
- Fix malformed HTML in the `#comprar` block that caused the “Opción 2” card to render below the grid instead of as the right column, so `.grid2` has exactly two direct `.card` children.

### Description
- Close the broken `onclick`/attribute on the WhatsApp button inside `#comprar` in `landing_venta.html` so the markup parses correctly and the full “Opción 2” card becomes the second direct sibling in `.grid2`.
- Change is minimal and limited to `landing_venta.html` inside the `#comprar` section and does not alter text, links, JS handlers, styles, or other sections.

### Testing
- Ran custom HTML parsing checks to count direct `.card` children inside `#comprar .grid2` which reported `1` before the fix and `2` after the fix, indicating the nesting was corrected (succeeded).
- Inspected the fixed lines with `nl`/`sed` and verified the WhatsApp button attribute is closed and the footer remains after the `grid2` closure (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969247a63988325acbcf8ad834f32c1)