### PR TITLE
Fix mobile test overlay overlap

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -707,13 +707,32 @@
       font-size:14px;
     }
     .testLockOverlay.is-hidden{display:none;}
-    @media (max-width: 480px){
+    @media (max-width: 520px){
       .testLockOverlay{
+        position:static;
+        inset:auto;
+        margin:0 0 12px;
+        width:100%;
         flex-direction:column;
         align-items:flex-start;
-        gap:10px;
-        font-size:clamp(14px, 4.2vw, 15px);
-        line-height:1.4;
+        gap:12px;
+        padding:16px;
+        font-size:15px;
+        line-height:1.5;
+      }
+      .testLockOverlay .btn{
+        width:100%;
+        justify-content:center;
+        text-align:center;
+        padding:12px 14px;
+      }
+    }
+    @media (max-width: 480px){
+      .testLockOverlay{
+        gap:12px;
+        padding:14px;
+        font-size:clamp(14px, 4.4vw, 15px);
+        line-height:1.55;
       }
       .testLockOverlay .btn{
         width:100%;


### PR DESCRIPTION
### Motivation
- Prevent the `.testLockOverlay` from overlapping underlying content on narrow viewports so the copy wraps legibly and the unlock button appears as a full-width control below the text.
- Also simplify form-opening behavior and remove an earlier share-preview/meta block as part of this landing file cleanup.

### Description
- Updated the mobile breakpoint at `@media (max-width: 520px)` to set `.testLockOverlay` to `position: static`, `inset: auto`, `margin: 0 0 12px`, `width: 100%`, `flex-direction: column`, increased `gap`/`padding` and adjusted `font-size`/`line-height` so the overlay pushes content instead of overlaying it.
- Made `.testLockOverlay .btn` full-width at the same breakpoint with centered text and increased padding to appear as a full-width control; kept an additional `@media (max-width: 480px)` tweak to further tune sizing.
- Removed four OG meta tags (`og:title`, `og:description`, `og:type`, `og:url`) from the file and removed the small share-preview block that previously mutated `document.title` and OG tags.
- Simplified `openLeadForm` to remove the `focusFieldId` parameter and always focus the `name` field, and updated the unlock button handler to call `openLeadForm()` without an argument.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696942452378832590465cc205a02870)