### PR TITLE
Hide duplicated .testGate message when test overlay is active (CSS-only)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -752,6 +752,7 @@
       opacity:.6;
       pointer-events:none;
     }
+    #testLockWrap.testLocked .testGate{display:none !important;}
     .checkList{display:grid;grid-template-columns:1fr 1fr;gap:10px}
     @media (max-width: 640px){.checkList{grid-template-columns:1fr}}
     .check{


### PR DESCRIPTION
### Motivation
- Prevent the duplicated lock message inside the test card when the overlay is active by hiding the internal `.testGate` element when `#testLockWrap` is in the locked state.

### Description
- Added a single CSS rule in `landing_venta.html`: `#testLockWrap.testLocked .testGate { display:none !important; }` to hide the internal block when the overlay is shown.
- Change is CSS-only and does not modify any JavaScript, copy, colors, or other behavior.

### Testing
- Launched a local server with `python -m http.server 8000` and ran a Playwright script that toggled the `testLocked` class on `#testLockWrap` and captured a screenshot `artifacts/test-lock-hidden.png`, which shows the internal `.testGate` hidden, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696952f4fca88325a7fdef25325065a9)