### PR TITLE
Ocultar overlay duplicado y agregar candado CSS en resultados

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -753,6 +753,8 @@
       pointer-events:none;
     }
     #testLockWrap.testLocked .testGate{display:none !important;}
+    #testLockWrap.testLocked #testLockOverlay{display:none !important;}
+    #testLockWrap.testLocked .testLockOverlay{display:none !important;}
     .checkList{display:grid;grid-template-columns:1fr 1fr;gap:10px}
     @media (max-width: 640px){.checkList{grid-template-columns:1fr}}
     .check{
@@ -830,6 +832,17 @@
     .resultBox.is-locked .resultText{
       border-color: rgba(11,107,58,.35);
       background: rgba(11,107,58,.18);
+    }
+    .resultBox.is-locked #resultText{
+      position:relative;
+      padding-left:52px;
+    }
+    .resultBox.is-locked #resultText::before{
+      content:"🔒";
+      position:absolute;
+      left:16px;
+      top:16px;
+      font-size:22px;
     }
     .shareCard{
       display:flex;gap:12px;align-items:flex-start;


### PR DESCRIPTION
### Motivation
- Evitar el texto duplicado cuando el test está bloqueado ocultando la franja superior del overlay y dejar solo el mensaje en el panel de resultados.
- Mostrar visualmente que el resultado está bloqueado añadiendo un candado antes del texto usando solo CSS sin tocar JS ni copy.

### Description
- Añadidas las reglas CSS `#testLockWrap.testLocked #testLockOverlay{display:none !important;}` y `#testLockWrap.testLocked .testLockOverlay{display:none !important;}` para ocultar la franja superior al estar bloqueado.
- Añadida la regla `.resultBox.is-locked #resultText` para posicionar y dejar espacio a la izquierda del texto con `padding-left:52px`.
- Añadido el pseudo-elemento `.resultBox.is-locked #resultText::before{ content:"🔒"; position:absolute; left:16px; top:16px; font-size:22px; }` para mostrar el candado antes del texto sin cambiar el copy.
- Cumple la restricción de cambios: solo se modificó el CSS dentro de `landing_venta.html` y no se tocó JS ni textos ni colores globales.

### Testing
- Levantado un servidor con `python -m http.server 8000` y cargado `landing_venta.html` en un navegador headless con Playwright, tomando la captura `artifacts/landing_venta_lock.png` para verificar visualmente; la captura se generó correctamente y muestra el overlay oculto y el candado en el panel derecho.
- No se ejecutaron pruebas unitarias automatizadas adicionales.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69695768d0c88325b4d1141ade8220eb)