### PR TITLE
Move unlock test button into result panel

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -773,6 +773,13 @@
       height:100%;
       display:flex;flex-direction:column;gap:10px;
     }
+    .resultBox #unlockTestBtn{
+      align-self:flex-end;
+      margin-top:4px;
+    }
+    @media (max-width: 640px){
+      .resultBox #unlockTestBtn{width:100%}
+    }
     .score{
       display:flex;align-items:center;justify-content:space-between;gap:10px;
       padding:16px 16px;border-radius:18px;
@@ -2044,7 +2051,6 @@ a.card.trustTile .pdrBoard{
         <div class="testLockWrap" id="testLockWrap">
           <div class="testLockOverlay" id="testLockOverlay">
             🔒 <span>Para ver tu resultado y usar el test, completa Nombre, Email y Teléfono (1 minuto).</span>
-            <button class="btn btnPrimary" type="button" id="unlockTestBtn">Desbloquear test</button>
           </div>
 
           <div class="testGrid" id="testGrid">
@@ -2082,6 +2088,7 @@ a.card.trustTile .pdrBoard{
               <div style="width:100%;background:var(--surface);border-radius:999px;height:8px;overflow:hidden;margin-top:6px;border:1px solid var(--border)">
                 <div id="scoreBar" style="height:100%;width:0%;background:var(--success);transition:width .18s ease"></div>
               </div>
+              <button class="btn btnPrimary" type="button" id="unlockTestBtn">Desbloquear test</button>
 
               <div class="resultText" id="resultText">
                 Para ver tu resultado y usar el test, completa Nombre, Email y Teléfono (1 minuto).


### PR DESCRIPTION
### Motivation
- The unlock control should appear inside the result panel when the test is locked so the “Desbloquear test” button is visually part of the right-hand result card instead of floating in the overlay.

### Description
- Moved the existing `#unlockTestBtn` from the `.testLockOverlay` into the `.resultBox` just above `#resultText` and removed the overlay copy.
- Kept the same element id `unlockTestBtn` and did not change any test logic or JS handlers.
- Added scoped CSS `.resultBox #unlockTestBtn` to align the button to the right and make it full width on mobile without altering global colors.
- Only `landing_venta.html` was modified.

### Testing
- Started a local server with `python -m http.server 8000` to serve the page (succeeded).
- Captured a visual smoke screenshot with Playwright to verify the button appears inside the result panel (artifact `artifacts/unlock-btn-panel.png`, succeeded).
- No unit tests were executed for this static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69695bfa5d708325a5de79688042dcc4)