### PR TITLE
Fix WhatsApp CTA message for Option 1 (Mexico product message)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -2335,7 +2335,7 @@ a.card.trustTile .pdrBoard{
               <p class="fine" style="margin-top:12px">Si prefieres, escríbenos por WhatsApp y te guiamos para escoger la opción correcta.</p>
               <div class="formActions" style="margin-top:14px">
                 <button class="btn btnPrimary btnXL" id="cta-buy-now-mx" type="button" onclick="openPurchase()">Comprar ahora</button>
-                <button class="btn btnSecondary" type="button" onclick="window.open('https://wa.me/17872321516?text=OPORTUNIDAD%20DE%20NEGOCIO%20%E2%80%94%20M%C3%89XICO%0AQuiero%20informaci%C3%B3n%20del%20Equipo%20Fundador.','_blank','noopener')"
+                <button class="btn btnSecondary" type="button" onclick="window.open('https://wa.me/17872321516?text=BARI%C3%81TRICA%20NATURAL%20%E2%80%94%20M%C3%89XICO%20%F0%9F%87%B2%F0%9F%87%BD%0AUnici-T%C3%A9%20%2B%20Balance%20%28Sistema%20Metab%C3%B3lico%29%0AQuiero%20informaci%C3%B3n%20del%20protocolo%20y%20c%C3%B3mo%20comprar.','_blank','noopener')"
 >WhatsApp</button>
               </div>
 


### PR DESCRIPTION
### Motivation
- Replace the incorrect business message sent by the Opción 1 WhatsApp CTA so it sends the product/protocol México message while leaving all other buttons and behavior unchanged.

### Description
- Update a single line in `landing_venta.html` to change the `onclick` URL for the Opción 1 WhatsApp button to open `https://wa.me/...` with the URL-encoded product message: "BARIÁTRICA NATURAL — MÉXICO 🇲🇽\nUnici-Té + Balance (Sistema Metabólico)\nQuiero información del protocolo y cómo comprar.".

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969620d92a083259be6df43bb313a38)