### PR TITLE
Update Mexico buy button link and remove onclick

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -2145,7 +2145,7 @@ a.card.trustTile .pdrBoard{
                 <li>Certificaciones evaluadas por terceros (según SKU/mercado).</li>
               </ul>
               <div class="formActions" style="margin-top:14px">
-                <a class="btn btnPrimary btnXL" id="cta-buy-system-mx" href="https://ufeelgreat.com/c/LaSaludesRiqueza" target="_blank" rel="noopener noreferrer" onclick="trackPurchase()">Comprar el sistema</a>
+                <a class="btn btnPrimary btnXL" id="cta-buy-system-mx" href="https://ufeelgreat.com/mex/es/product/feel-great?sku=36279" target="_blank" rel="noopener noreferrer">Comprar el sistema</a>
               </div>
 </div>
           </div>


### PR DESCRIPTION
### Motivation
- Ensure the Mexico-specific "Comprar el sistema" button opens the correct Mexico product page and does not trigger the `trackPurchase()` handler that was causing an unwanted redirect.

### Description
- In `landing_venta.html` update the anchor with `id="cta-buy-system-mx"` to use `href="https://ufeelgreat.com/mex/es/product/feel-great?sku=36279"` and remove the `onclick="trackPurchase()"` attribute while keeping `target="_blank"` and `rel="noopener noreferrer"`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69696557fedc832595bf46b2804997ed)