### PR TITLE
WhatsApp: usar "SOY: {name_full}" y "Ciudad: {city}" en mensaje de resultado

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -2778,6 +2778,13 @@ a.card.trustTile .pdrBoard{
     function buildTestMessage(score, keys, firstName){
       const safeName = escapeHtml(firstName);
       const greeting = safeName ? `Hola, ${safeName} 👋` : "Hola 👋";
+      const lead = normalizeLead(getBnLead()) || {};
+      const leadName = (lead.name_full || firstName || "").toString().trim();
+      const leadCity = (lead.city || "").toString().trim();
+      const plainHeaderLines = [];
+      if(leadName){ plainHeaderLines.push(`SOY: ${leadName}`); }
+      if(leadCity){ plainHeaderLines.push(`Ciudad: ${leadCity}`); }
+      const plainHeader = plainHeaderLines.join("\n");
 
       const ranges = [
         {
@@ -2903,7 +2910,7 @@ a.card.trustTile .pdrBoard{
         <p><strong>Si quieres guía paso a paso con Unici-Té + Balance, escribe METABOLISMO.</strong></p>
       `;
 
-      const plainText = `${greeting}\n\nNivel: ${range.label}.\n${range.intro}\n\n¿Por qué puede pasar? ${range.why}\n\n3 acciones concretas:\n• ${range.actions.join("\n• ")}\n\n${range.medical}\n${modules.length ? "\nPatrones detectados:\n" + modules.slice(0, 3).map(mod=>`• ${mod.title}: ${mod.text} Acción: ${mod.action}`).join("\n") : ""}\n\nEducativo, no diagnóstico.\n\nSi quieres guía paso a paso con Unici-Té + Balance, escribe METABOLISMO.`;
+      const plainText = `${plainHeader}\n\nNivel: ${range.label}.\n${range.intro}\n\n¿Por qué puede pasar? ${range.why}\n\n3 acciones concretas:\n• ${range.actions.join("\n• ")}\n\n${range.medical}\n${modules.length ? "\nPatrones detectados:\n" + modules.slice(0, 3).map(mod=>`• ${mod.title}: ${mod.text} Acción: ${mod.action}`).join("\n") : ""}\n\nEducativo, no diagnóstico.\n\nSi quieres guía paso a paso con Unici-Té + Balance, escribe METABOLISMO.`;
 
       return { html, plainText };
     }


### PR DESCRIPTION
### Motivation
- Al enviar el resultado por WhatsApp el encabezado debe iniciar con `SOY: {name_full}` y agregar `Ciudad: {city}` solo si existe en `bn_lead`.
- No deben cambiarse rangos, lógica del resultado, ni otros botones; solo el encabezado del texto plano enviado por WhatsApp.
- Implementar el cambio donde se construye el `plainText` del mensaje de resultado (`buildTestMessage`).

### Description
- Se actualizó `landing_venta.html` en la función `buildTestMessage` para obtener el lead con `normalizeLead(getBnLead())` y construir un `plainHeader` con `SOY: {name_full}` y opcional `Ciudad: {city}`.
- Se reemplazó el saludo inicial en el `plainText` por el nuevo `plainHeader`, preservando intactos los `ranges`, `modules` y el contenido del resultado.
- No se modificó la salida HTML usada en la interfaz; el cambio aplica solo al texto plano que se envía por WhatsApp.

### Testing
- No se ejecutaron pruebas automáticas en CI para este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69696d22318083259ac0763b0cb00294)