### PR TITLE
UX: Solo el botón `#unlockTestBtn` abre el formulario (remueve listener en `#testLockWrap`)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -3327,13 +3327,6 @@ a.card.trustTile .pdrBoard{
     setTestLockedState(!leadSubmitted);
 
     const _testWrap = document.getElementById("testLockWrap");
-    if(_testWrap){
-      _testWrap.addEventListener("click", (e)=>{
-        if(leadSubmitted){ return; }
-        e.preventDefault();
-        openLeadForm();
-      });
-    }
 
     const _unlockBtn = document.getElementById("unlockTestBtn");
     if(_unlockBtn){


### PR DESCRIPTION
### Motivation
- Evitar que clics en el panel/candado (`#testLockWrap`, `#resultText` u otras áreas) abran el formulario de lead; solo el botón naranja `#unlockTestBtn` debe iniciar el flujo de desbloqueo.

### Description
- Se eliminó el listener de `click` adjuntado a `#testLockWrap` para que ya no invoque `openLeadForm()`, manteniendo intacto el handler de `#unlockTestBtn` que hace `openLeadForm("email")` y controla el foco/scroll.

### Testing
- No se ejecutaron tests automatizados durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969734cb6648325a563713b530ee880)