### PR TITLE
Solo #unlockTestBtn abre el formulario y se asegura su clickeabilidad

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -840,6 +840,17 @@
       border-color: rgba(11,107,58,.35);
       background: rgba(11,107,58,.18);
     }
+    .resultBox.is-locked{
+      pointer-events:auto;
+    }
+    .resultBox.is-locked #unlockTestBtn{
+      position:relative;
+      z-index:10;
+      pointer-events:auto;
+    }
+    .resultBox.is-locked #resultText{
+      pointer-events:none;
+    }
     .resultBox.is-locked #resultText{
       position:relative;
       padding-left:52px;
@@ -3005,6 +3016,7 @@ a.card.trustTile .pdrBoard{
       if(overlay){ overlay.classList.toggle("is-hidden", !isLocked); }
       checks.forEach(c=>{ c.disabled = isLocked; });
       buttons.forEach(btn=>{
+        if(btn.id === "unlockTestBtn"){ return; }
         btn.disabled = isLocked;
         btn.setAttribute("aria-disabled", isLocked ? "true" : "false");
       });


### PR DESCRIPTION
### Motivation

- Corrige un comportamiento en el panel de resultado bloqueado donde el panel/candado recibían clicks y el botón naranja no siempre era clickeable; el objetivo es que SOLO `#unlockTestBtn` abra el formulario.
- Mantener el resto del área del panel inactiva cuando el test está bloqueado para evitar llamadas accidentales a `openLeadForm()`.

### Description

- Añadido CSS scoped al bloque del test para que `.resultBox.is-locked` permita `pointer-events`, y que `#unlockTestBtn` tenga `position:relative`, `z-index:10` y `pointer-events:auto` para que quede por encima y reciba clicks.
- Añadido CSS para que `.resultBox.is-locked #resultText` tenga `pointer-events:none` evitando que el texto o el panel capturen clicks cuando está bloqueado.
- Modificado `setTestLockedState` para que al deshabilitar botones dentro de `#testGrid` se salte el botón con `id === "unlockTestBtn"`, manteniéndolo habilitado aunque el resto quede bloqueado.

### Testing

- Se inició un servidor local con `python -m http.server 8000` y el servidor quedó en ejecución (éxito). 
- Se intentó generar una captura con Playwright para verificar visualmente la zona del test, pero la ejecución de Playwright agotó el tiempo de espera en este entorno (falló).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969763cb508832598ff4be7e8894808)