### PR TITLE
UX móvil: botón 'Desbloquear test' sticky cuando el test está bloqueado

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -780,6 +780,15 @@
     @media (max-width: 640px){
       .resultBox #unlockTestBtn{width:100%}
     }
+    @media (max-width: 520px){
+      .resultBox.is-locked #unlockTestBtn{
+        position:sticky;
+        top:12px;
+        z-index:6;
+        margin:0 0 12px;
+        align-self:stretch;
+      }
+    }
     .score{
       display:flex;align-items:center;justify-content:space-between;gap:10px;
       padding:16px 16px;border-radius:18px;


### PR DESCRIPTION
### Motivation
- Mantener visible el botón `#unlockTestBtn` en pantallas móviles (`@media (max-width: 520px)`) cuando el test está bloqueado para que el usuario lo vea antes de intentar marcar opciones.

### Description
- Añadido CSS en `landing_venta.html` que aplica `position: sticky` a `.resultBox.is-locked #unlockTestBtn` dentro de `@media (max-width: 520px)`, con `top`, `z-index`, `margin` y `align-self: stretch` para mantener el botón fijo cerca de la parte superior del área del test.

### Testing
- Se lanzó un servidor estático y se ejecutó un script Headless Playwright que tomó una captura en viewport `520x900`, produciendo `artifacts/landing_venta_mobile_unlock_sticky.png`, confirmando visualmente que el botón queda sticky en móvil (captura generada correctamente).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a63207dc08325808dd1b535fb60f6)