### PR TITLE
Fix mobile locked test CTA positioning (CSS only)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -781,11 +781,16 @@
       .resultBox #unlockTestBtn{width:100%}
     }
     @media (max-width: 520px){
-      .resultBox.is-locked #unlockTestBtn{
-        position:sticky;
+      #testLockWrap.testLocked{
+        padding-top:72px;
+      }
+      #testLockWrap.testLocked #unlockTestBtn{
+        position:fixed;
         top:12px;
-        z-index:6;
-        margin:0 0 12px;
+        left:16px;
+        right:16px;
+        z-index:9999;
+        margin:0;
         align-self:stretch;
       }
     }


### PR DESCRIPTION
### Motivation
- On iPhone `position: sticky` failed to keep the “Desbloquear test” CTA visible because of overflow/scroll containers, so the CTA must be fixed when the test is locked on small screens.

### Description
- Replace the previous mobile sticky rule with a fixed CTA under `#testLockWrap.testLocked` in `landing_venta.html` for `@media (max-width: 520px)` only. 
- Add `padding-top:72px` to `#testLockWrap.testLocked` so the fixed CTA does not overlap content. 
- Apply `#testLockWrap.testLocked #unlockTestBtn { position: fixed; top:12px; left:16px; right:16px; z-index:9999; margin:0; }` so the button is fixed on mobile while locked. 
- Change is CSS-only, scoped to mobile locked state, affects only `landing_venta.html` and does not modify JS, text, colors, desktop behavior, or duplicate buttons.

### Testing
- Started a local HTTP server and verified the page responds with `HTTP/1.0 200 OK` using `curl -I`, which succeeded. 
- Attempted automated visual verification with Playwright to add the `testLocked` class and capture a screenshot, but the Playwright runs timed out or failed to find the selector, so screenshots were not produced. 
- No unit tests or other automated test suites were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a697ddcd0832586b41550d222df2a)