### PR TITLE
Show test unlock bar when result is locked (CSS only)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -788,6 +788,14 @@
     .testLocked .testUnlockBar{
       display:flex !important;
     }
+    #test:has(.resultBox.is-locked) .testUnlockBar{
+      display:flex !important;
+    }
+    @media (max-width: 520px){
+      #test:has(.resultBox.is-locked) .testUnlockBar{
+        display:flex !important;
+      }
+    }
     @media (max-width: 640px){
       .testUnlockBar{
         flex-direction:column;


### PR DESCRIPTION
### Motivation
- Fix iPhone layout where the unlock bar (`.testUnlockBar`) stayed hidden even when the test was locked; the reliable locked state in this layout is `.resultBox.is-locked` and the fix must be CSS-only.

### Description
- Add a CSS rule `#test:has(.resultBox.is-locked) .testUnlockBar { display:flex !important; }` and a matching `@media (max-width: 520px)` variant so the bar is revealed when the result is locked without touching JS or other assets.

### Testing
- Started a local server with `python -m http.server 8000` and ran a Playwright render at an iPhone viewport (390x844) to verify the unlock bar is visible; the first attempt failed due to a `querySelector` timing issue but a subsequent run succeeded and produced a screenshot (`artifacts/test-unlock-bar.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a7bc84d0c832588e36b6ba4ad6d7a)