### PR TITLE
Ocultar candado duplicado en panel de resultado en móvil

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -899,6 +899,12 @@
       top:16px;
       font-size:22px;
     }
+    @media (max-width: 520px){
+      .resultBox.is-locked #resultText::before{
+        display:none !important;
+        content:none !important;
+      }
+    }
     .shareCard{
       display:flex;gap:12px;align-items:flex-start;
       padding:14px 16px;


### PR DESCRIPTION
### Motivation
- Evitar que el candado añadido por CSS en `#resultText::before` aparezca duplicado en móviles, manteniendo el candado correcto en la barra superior.

### Description
- Añadida una regla `@media (max-width: 520px)` que aplica `display:none !important; content:none !important;` a `.resultBox.is-locked #resultText::before` para ocultar el icono en móvil sin tocar JS ni el texto.

### Testing
- Levantado un servidor con `python -m http.server 8000` y ejecutado un script Playwright con viewport `390x844` que cargó `landing_venta.html` y tomó una captura, comprobando que solo permanece el candado superior (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a80da35b883258df75462c134bb8d)