### PR TITLE
Mover botón “Desbloquear test” dentro del panel de resultado en desktop

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -806,6 +806,19 @@
         width:100%;
       }
     }
+    @media (min-width: 641px){
+      .testUnlockBar{
+        display:none !important;
+      }
+      .resultBox.is-locked #unlockTestBtn{
+        width:100%;
+        justify-content:center;
+        margin-top:4px;
+      }
+      .resultBox:not(.is-locked) #unlockTestBtn{
+        display:none;
+      }
+    }
     .check{
       display:flex;gap:10px;align-items:flex-start;
       padding:14px 14px;
@@ -3399,6 +3412,15 @@ a.card.trustTile .pdrBoard{
         }
       });
     }
+    (function moveUnlockBtnToResultBox(){
+      if(!window.matchMedia || !window.matchMedia("(min-width: 641px)").matches){ return; }
+      const unlockBtn = document.getElementById("unlockTestBtn");
+      const resultText = document.getElementById("resultText");
+      const resultBox = document.querySelector(".resultBox");
+      if(!unlockBtn || !resultText || !resultBox){ return; }
+      if(resultBox.contains(unlockBtn)){ return; }
+      resultText.insertAdjacentElement("afterend", unlockBtn);
+    })();
 
     if(isShareMode){
       scrollToId("test");


### PR DESCRIPTION
### Motivation
- Quitar el candado/texto superior izquierdo en pantallas de escritorio y mostrar el CTA principal de desbloqueo dentro del panel derecho bajo el mensaje de resultado para mejorar la jerarquía visual en desktop.
- Mantener la experiencia móvil sin cambios y no tocar la lógica del test, copy global ni otros botones.
- Realizar cambios mínimos usando solo CSS y una pequeña rutina JS para reubicar el mismo botón sin duplicarlo ni cambiar su id.

### Description
- Oculta la barra superior de desbloqueo en desktop mediante una regla `@media (min-width: 641px)` que aplica `display:none !important` a `.testUnlockBar` en `landing_venta.html`.
- Añade reglas desktop para que el botón `#unlockTestBtn` se muestre solo dentro de la `.resultBox.is-locked` con `width:100%` y `margin-top:4px`, y se oculte cuando `.resultBox` no esté bloqueada.
- Añade una micro-rutina IIFE `moveUnlockBtnToResultBox()` que, cuando la pantalla es desktop, mueve el nodo existente `#unlockTestBtn` justo después de `#resultText` dentro de `.resultBox` sin alterar sus handlers.
- No se duplica el botón ni se cambia su id ni se modifica la lógica de desbloqueo; el handler existente sigue intacto.

### Testing
- Levanté un servidor estático con `python -m http.server 8000` para validar la página localmente and it started successfully.
- Intenté capturar una captura de pantalla de escritorio con Playwright (`viewport 1280x720`) pero el script hizo timeout y falló to produce a screenshot.
- No se ejecutaron suites de tests automatizados adicionales (no hay tests unitarios relevantes para este cambio de HTML/CSS/JS).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a88db878c83258ef08d4472ac232c)