### PR TITLE
Mobile: video-first hero layout (≤980px)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -189,7 +189,20 @@
       align-items:stretch;
     }
     @media (max-width: 980px){
-      .heroGrid{grid-template-columns:1fr;gap:14px}
+      .heroGrid{
+        display:flex;
+        flex-direction:column;
+        gap:14px;
+      }
+      .heroGrid > .videoShell{order:0}
+      .heroGrid > .panel:not(.videoShell){order:1}
+      .videoShell{
+        display:flex;
+        flex-direction:column;
+      }
+      .videoShell .videoTop{order:0}
+      .videoShell .videoFrame{order:1}
+      .videoShell .hint{order:2}
       .navLinks{justify-content:flex-start}
     }
     .panel{


### PR DESCRIPTION
### Motivation
- Ensure that on mobile screens (≤980px) the `.panel.videoShell` appears first in the HERO and the text/form panel appears below.
- Keep the video frame above its descriptive card so the `.hint` remains immediately under the video.
- Implement this reordering using CSS only while leaving desktop, copy, JS, colors, buttons, links, and OG/share untouched.

### Description
- Update `landing_venta.html` CSS `@media (max-width: 980px)` to set `.heroGrid` to `display:flex` with `flex-direction:column` and `gap:14px`.
- Add ordering rules ` .heroGrid > .videoShell { order: 0 }` and `.heroGrid > .panel:not(.videoShell) { order: 1 }` to make the video panel render first.
- Make `.videoShell` a column flex container and enforce child order with `.videoShell .videoTop { order: 0 }`, `.videoShell .videoFrame { order: 1 }`, and `.videoShell .hint { order: 2 }` so the hint stays below the video.
- Only `landing_venta.html` was modified and no other assets or behavior were changed.

### Testing
- The site was served with `python -m http.server 8000` and a Playwright script loaded `landing_venta.html` at a mobile viewport (390×844) and produced a screenshot at `artifacts/landing_venta_mobile.png`, which completed successfully.
- No automated unit tests exist for this visual CSS change and visual verification passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a926576848325a4324be6eabecf33)