### PR TITLE
Replace #confianza icons with logo images (PDR + certifications)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1347,12 +1347,15 @@
     .pdrBoard{justify-content:center; gap:10px;}
     .pdrRow{display:flex;align-items:center;gap:10px}
     .pdrIcon{
-      width:64px;height:64px;border-radius:18px;
+      width:72px;height:72px;border-radius:20px;
       background: rgba(11,107,58,.18);
       border:1px solid rgba(11,107,58,.45);
       display:flex;align-items:center;justify-content:center;
       box-shadow: 0 14px 26px rgba(15,23,42,.12);
       flex:0 0 auto;
+      padding:10px;
+      position:relative;
+      overflow:hidden;
     }
     #confianza .pdrIcon{
       background: rgba(11,107,58,.24);
@@ -1361,7 +1364,11 @@
         0 0 0 1px rgba(11,18,32,.25),
         0 16px 28px rgba(15,23,42,.18);
     }
-    .pdrIcon svg{width:34px;height:34px;fill:none;stroke:rgba(11,107,58,.98);stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
+    #confianza .pdrIcon img{
+      width:100%;height:100%;
+      object-fit:contain;
+      display:block;
+    }
     .pdrTxt b{display:block;font-size:20px;letter-spacing:-.2px}
     .pdrTxt span{display:block;margin-top:4px;color:rgba(71,85,105,.9);font-size:14px;line-height:1.35}
     .pdrTxt em{display:block;margin-top:6px;color:rgba(71,85,105,.78);font-size:12.5px;font-style:normal;line-height:1.35}
@@ -1387,13 +1394,20 @@
       background:var(--surface);
     }
     .certIcon{
-      width:32px;height:32px;border-radius:12px;
+      width:40px;height:40px;border-radius:12px;
       background: rgba(11,107,58,.12);
       border:1px solid rgba(11,107,58,.32);
       display:flex;align-items:center;justify-content:center;
       flex:0 0 auto;
+      padding:6px;
+      position:relative;
+      overflow:hidden;
     }
-    .certIcon svg{width:18px;height:18px;fill:none;stroke:rgba(11,107,58,.95);stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
+    #confianza .certIcon img{
+      width:100%;height:100%;
+      object-fit:contain;
+      display:block;
+    }
     .certTxt strong{display:block;font-size:11.5px;line-height:1.05;color:var(--text)}
     .certTxt span{display:block;margin-top:2px;font-size:10.5px;line-height:1.15;color:rgba(71,85,105,.72)}
 
@@ -2274,17 +2288,11 @@ a.card.trustTile .pdrBoard{
               <a class="card trustTile" href="https://www.pdr.net/full-prescribing-information/hl/?druglabelid=24170" target="_blank" rel="noopener" aria-label="Abrir evidencia PDR">
               <div class="trustMedia">
                 <div class="trustBoard pdrBoard">
-                  <div class="pdrRow">
-                    <div class="pdrIcon" aria-hidden="true">
-                      <svg viewBox="0 0 24 24">
-                        <path d="M6 4h10a3 3 0 0 1 3 3v13H8a3 3 0 0 0-2 0V4z"/>
-                        <path d="M6 4v16"/>
-                        <path d="M9 8h7"/>
-                        <path d="M9 12h7"/>
-                        <path d="M9 16h5"/>
-                      </svg>
-                    </div>
-                    <div class="pdrTxt">
+                    <div class="pdrRow">
+                      <div class="pdrIcon">
+                        <img src="assets/logos/pdr.svg" alt="PDR" loading="lazy" onerror="this.onerror=null;this.src=&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 80 80'%3E%3Crect width='80' height='80' rx='18' fill='%230b6b3a'/%3E%3Ctext x='50%25' y='54%25' text-anchor='middle' font-family='Segoe UI,Arial' font-size='24' font-weight='700' fill='white'%3EPDR%3C/text%3E%3C/svg%3E&quot;;" />
+                      </div>
+                      <div class="pdrTxt">
                       <b>PDR</b>
                       <span>Prescribers’ Digital Reference</span>
                                           </div>
@@ -2311,65 +2319,43 @@ a.card.trustTile .pdrBoard{
 
                   <div class="certGrid">
                     <div class="certBadge">
-                      <div class="certIcon" aria-hidden="true">
-                        <svg viewBox="0 0 24 24">
-                          <path d="M12 3l7 4v6c0 5-3 8-7 8s-7-3-7-8V7l7-4z"/>
-                          <path d="M9 12l2 2 4-4"/>
-                        </svg>
+                      <div class="certIcon">
+                        <img src="assets/logos/nsf.svg" alt="NSF" loading="lazy" onerror="this.onerror=null;this.src=&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230b6b3a'/%3E%3Ctext x='50%25' y='54%25' text-anchor='middle' font-family='Segoe UI,Arial' font-size='18' font-weight='700' fill='white'%3ENSF%3C/text%3E%3C/svg%3E&quot;;" />
                       </div>
                       <div class="certTxt"><strong>NSF</strong><span>Calidad y seguridad</span></div>
                     </div>
 
                     <div class="certBadge">
-                      <div class="certIcon" aria-hidden="true">
-                        <svg viewBox="0 0 24 24">
-                          <path d="M7 21V10l5 3v-3l5 3V9l5 3v9H7z"/>
-                          <path d="M11 21v-6"/>
-                          <path d="M15 21v-6"/>
-                        </svg>
+                      <div class="certIcon">
+                        <img src="assets/logos/cgmp.svg" alt="cGMP" loading="lazy" onerror="this.onerror=null;this.src=&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230b6b3a'/%3E%3Ctext x='50%25' y='54%25' text-anchor='middle' font-family='Segoe UI,Arial' font-size='16' font-weight='700' fill='white'%3EcGMP%3C/text%3E%3C/svg%3E&quot;;" />
                       </div>
                       <div class="certTxt"><strong>cGMP</strong><span>Buenas prácticas</span></div>
                     </div>
 
                     <div class="certBadge">
-                      <div class="certIcon" aria-hidden="true">
-                        <svg viewBox="0 0 24 24">
-                          <path d="M9 4h6l1 2h3v16H5V6h3l1-2z"/>
-                          <path d="M9 4v4h6V4"/>
-                          <path d="M8 12h8"/>
-                          <path d="M8 16h6"/>
-                        </svg>
+                      <div class="certIcon">
+                        <img src="assets/logos/iso9001.svg" alt="ISO-9001" loading="lazy" onerror="this.onerror=null;this.src=&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230b6b3a'/%3E%3Ctext x='50%25' y='52%25' text-anchor='middle' font-family='Segoe UI,Arial' font-size='12' font-weight='700' fill='white'%3EISO%209001%3C/text%3E%3C/svg%3E&quot;;" />
                       </div>
                       <div class="certTxt"><strong>ISO‑9001</strong><span>Gestión de calidad</span></div>
                     </div>
 
                     <div class="certBadge">
-                      <div class="certIcon" aria-hidden="true">
-                        <svg viewBox="0 0 24 24">
-                          <path d="M15 3a8 8 0 1 0 0 18a7 7 0 1 1 0-18z"/>
-                        </svg>
+                      <div class="certIcon">
+                        <img src="assets/logos/halal.svg" alt="Halal" loading="lazy" onerror="this.onerror=null;this.src=&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230b6b3a'/%3E%3Ctext x='50%25' y='54%25' text-anchor='middle' font-family='Segoe UI,Arial' font-size='16' font-weight='700' fill='white'%3EHalal%3C/text%3E%3C/svg%3E&quot;;" />
                       </div>
                       <div class="certTxt"><strong>Halal</strong><span>Certificación</span></div>
                     </div>
 
                     <div class="certBadge">
-                      <div class="certIcon" aria-hidden="true">
-                        <svg viewBox="0 0 24 24">
-                          <path d="M12 3l3.5 6H8.5L12 3z"/>
-                          <path d="M12 21l-3.5-6h7L12 21z"/>
-                          <path d="M8.5 9h7l3.5 6H5l3.5-6z"/>
-                        </svg>
+                      <div class="certIcon">
+                        <img src="assets/logos/kosher.svg" alt="Kosher" loading="lazy" onerror="this.onerror=null;this.src=&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230b6b3a'/%3E%3Ctext x='50%25' y='54%25' text-anchor='middle' font-family='Segoe UI,Arial' font-size='14' font-weight='700' fill='white'%3EKosher%3C/text%3E%3C/svg%3E&quot;;" />
                       </div>
                       <div class="certTxt"><strong>Kosher</strong><span>Certificación</span></div>
                     </div>
 
                     <div class="certBadge">
-                      <div class="certIcon" aria-hidden="true">
-                        <svg viewBox="0 0 24 24">
-                          <path d="M7 8h10v4H7z"/>
-                          <path d="M5 12h14v4H5z"/>
-                          <path d="M8 16v5h8v-5"/>
-                        </svg>
+                      <div class="certIcon">
+                        <img src="assets/logos/tga.svg" alt="TGA" loading="lazy" onerror="this.onerror=null;this.src=&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230b6b3a'/%3E%3Ctext x='50%25' y='54%25' text-anchor='middle' font-family='Segoe UI,Arial' font-size='18' font-weight='700' fill='white'%3ETGA%3C/text%3E%3C/svg%3E&quot;;" />
                       </div>
                       <div class="certTxt"><strong>TGA</strong><span>Regulación</span></div>
                     </div>


### PR DESCRIPTION
### Motivation
- Mejorar la presencia visual de la sección `#confianza` sustituyendo los iconos sobrios por logos reales para mayor impacto sin alterar copy ni el estilo general. 
- Mantener estructura, colores y comportamiento responsive de la sección mientras se facilita la incorporación posterior de archivos reales en `assets/logos/`.
- Garantizar accesibilidad básica añadiendo `alt` descriptivos a cada logo.

### Description
- Actualicé solo `landing_venta.html` para reemplazar los SVG de iconos en el tile PDR y en las badges de certificaciones por `<img>` que apuntan a `assets/logos/{pdr,nsf,cgmp,iso9001,halal,kosher,tga}.svg` y añadí `alt` con los nombres correspondientes. 
- Ajusté estilos dentro de `#confianza` para soportar imágenes (`.pdrIcon` redimensionada a `72x72` con padding y `.certIcon` a `40x40`) y mantener bordes, radios y sombras del diseño premium. 
- Implementé fallbacks integrados usando `onerror` con SVG data-URI placeholders para que la sección muestre un monograma premium si los archivos `assets/logos/*.svg` no existen aún. 
- No se tocaron otros archivos ni se cambió texto visible salvo los `alt` necesarios para accesibilidad; tampoco se modificaron configuraciones externas (SniperMind/RAI) ni otras secciones.

### Testing
- Intenté pruebas visuales abriendo un servidor local y capturar pantallas con Playwright, pero Chromium explotó en el contenedor y no se pudieron generar las capturas, por lo que no hay screenshots automatizados disponibles. 
- Se comprobó manualmente que el HTML y CSS cambiados no introducen errores sintácticos y el cambio fue commit-ado; no se ejecutaron tests unitarios automatizados porque es una modificación estática de la plantilla. 
- Resultado: cambios aplicados y validados estáticamente en `landing_venta.html`, sin pruebas visuales automatizadas por fallo del navegador en CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa36315a4832580d79c04bf895e2d)