### PR TITLE
Ajustar padding móvil en certificaciones de #confianza

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1444,6 +1444,13 @@
       color:#F8FAFC !important;
       box-shadow: 0 12px 30px rgba(0,0,0,.35) !important;
     }
+    @media (max-width: 640px){
+      #confianza .wrap{padding-inline:16px;}
+      #confianza .cardPad{padding-inline:16px;}
+      #confianza .trustBoard.certBoard{padding-inline:16px;}
+      #confianza .certGrid{gap:12px;}
+      #confianza .certBadge{width:100%;box-sizing:border-box;}
+    }
 
     #incluye .sectionTitle p{
       color:rgba(226,232,240,.95);


### PR DESCRIPTION
### Motivation
- Evitar que los badges de la columna de certificaciones en la sección `#confianza` queden pegados al borde en móvil manteniendo el diseño de escritorio intacto.

### Description
- Agregué un bloque `@media (max-width: 640px)` en `landing_venta.html` que aplica `padding-inline:16px` a `#confianza .wrap` y `#confianza .cardPad`, añade `padding-inline:16px` a `#confianza .trustBoard.certBoard`, ajusta el `gap` de `#confianza .certGrid` a `12px` y fuerza `width:100%` con `box-sizing:border-box` en `#confianza .certBadge`.

### Testing
- Levanté un servidor estático con `python -m http.server` (OK) y luego intenté capturar la vista móvil con Playwright para verificar el resultado, pero el intento de screenshot falló por timeout (Playwright timed out).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa9b043908325bef14e557dc3f8e7)