### PR TITLE
HOTFIX (mobile): prevent clipping of #confianza badges

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1138,6 +1138,22 @@
     .certTxt strong{display:block;font-size:11.5px;line-height:1.05;color:var(--text)}
     .certTxt span{display:block;margin-top:2px;font-size:10.5px;line-height:1.15;color:rgba(71,85,105,.72)}
 
+    @media (max-width: 640px){
+      #confianza .wrap{padding-left:16px;padding-right:16px;}
+      #confianza{overflow:visible;}
+      #confianza .trustBrief{overflow:visible;}
+      #confianza .trustGallery{grid-template-columns:minmax(0,1fr) minmax(0,1fr);}
+      #confianza .trustGallery > *{min-width:0;}
+      #confianza .certGrid{grid-template-columns:minmax(0,1fr) minmax(0,1fr);}
+      #confianza .certGrid > *{min-width:0;}
+      #confianza .certBadge,
+      #confianza .certBadge *{
+        max-width:100%;
+        box-sizing:border-box;
+      }
+      #confianza .certTxt{min-width:0;}
+    }
+
     .trustCap{padding:14px 16px}
     .trustCap strong{display:block;font-size:14px}
     .trustCap span{display:block;margin-top:4px;color:rgba(71,85,105,.78);font-size:12.5px;line-height:1.35}


### PR DESCRIPTION
### Motivation
- The right column of the `#confianza` section was being clipped on small devices (notably iPhone), so badges and cards could be cut by the right edge. 
- The fix must be CSS-only and limited to `landing_venta.html` to avoid touching HTML/JS or other sections.

### Description
- Added a mobile-only `@media (max-width: 640px)` block in `landing_venta.html` that ensures lateral padding by setting `#confianza .wrap{padding-left:16px;padding-right:16px;}`. 
- Removed clipping by making `#confianza` and `#confianza .trustBrief` `overflow:visible`. 
- Made grids robust to shrinking by switching `trustGallery` and `certGrid` to `grid-template-columns: minmax(0,1fr) minmax(0,1fr);` and setting `min-width:0` on their children. 
- Prevented badges from overflowing by constraining `.certBadge` and its descendants with `max-width:100%` and `box-sizing:border-box`, and adding `min-width:0` for `.certTxt` so text can wrap/shrink properly.

### Testing
- Started a local server with `python -m http.server` to serve the updated `landing_venta.html`, which launched successfully. 
- Attempted an automated visual check using a Playwright script to capture a mobile viewport screenshot, but the Chromium headless run failed with a `SIGSEGV/TargetClosedError` so the screenshot check did not complete. 
- The CSS change was applied and the file `landing_venta.html` was updated and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aceed9fd88325bb1fce291cdcb798)