### PR TITLE
HOTFIX: Forzar 1 columna en #confianza en móviles / WhatsApp iOS (solo CSS)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1154,6 +1154,33 @@
       #confianza .certTxt{min-width:0;}
     }
 
+    @media (max-width: 980px){
+      /* HOTFIX MÓVIL (WA/Safari): evitar desktop comprimido */
+      #confianza{overflow-x:hidden;overflow-y:visible;}
+
+      /* Forzar 1 columna en el grid principal de confianza */
+      #confianza .trustGrid{
+        grid-template-columns: 1fr !important;
+        gap: 14px !important;
+      }
+
+      /* Asegurar que cada card no exceda el viewport */
+      #confianza .trustCard,
+      #confianza .trustBrief{
+        width: 100% !important;
+        max-width: 100% !important;
+      }
+
+      /* Grid interno de certificaciones: 2 columnas fluidas sin recorte */
+      #confianza .certGrid{
+        grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+      }
+      #confianza .certBadge,
+      #confianza .certTxt{
+        min-width: 0 !important;
+      }
+    }
+
     .trustCap{padding:14px 16px}
     .trustCap strong{display:block;font-size:14px}
     .trustCap span{display:block;margin-top:4px;color:rgba(71,85,105,.78);font-size:12.5px;line-height:1.35}


### PR DESCRIPTION
### Motivation

- Resolver un problema donde la sección `#confianza` se renderiza comprimida como layout de escritorio (2 columnas) en pantallas móviles y en el navegador in-app de WhatsApp/Safari de iPhone, quedando ilegible. 
- El objetivo es que en vistas móviles `#confianza` sea 1 columna (PDR arriba, Certificaciones abajo) sin recortes ni compresión. 
- Restricción: solo cambios CSS y únicamente en `landing_venta.html`.

### Description

- Añadido un bloque `@media (max-width: 980px)` al final del CSS en `landing_venta.html` que aplica el hotfix móvil diseñado para cubrir Safari y WhatsApp in-app. 
- Reglas clave incluidas: `#confianza{ overflow-x:hidden; overflow-y:visible; }`, forzar `#confianza .trustGrid { grid-template-columns: 1fr !important; gap:14px !important; }`, y asegurar que `#confianza .trustCard` y `#confianza .trustBrief` usen `width:100% !important; max-width:100% !important;`. 
- Ajuste adicional para la grilla de certificaciones con `#confianza .certGrid { grid-template-columns: repeat(2, minmax(0, 1fr)) !important; }` y `min-width:0 !important` en `.certBadge` / `.certTxt` para evitar recortes.

### Testing

- Levanté un servidor local y ejecuté un script Playwright con viewport `375x812` para capturar una captura de `http://127.0.0.1:8000/landing_venta.html`, generando el archivo `artifacts/confianza-mobile.png`, y la captura muestra la sección en una sola columna según lo esperado (éxito). 
- La verificación está limitada a la captura automatizada y visual; no se ejecutaron suites de tests adicionales automatizados (no aplica para este cambio CSS aislado).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ad69dd75483258dea462910489e92)