### PR TITLE
Hotfix: single-column mobile cert grid in landing_venta.html

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1154,6 +1154,16 @@
       #confianza .certTxt{min-width:0;}
     }
 
+    @media (max-width: 420px){
+      #confianza .certGrid{grid-template-columns:1fr;}
+      #confianza .certBadge,
+      #confianza .certBadge *,
+      #confianza .certTxt{
+        min-width:0;
+        box-sizing:border-box;
+      }
+    }
+
     @media (max-width: 980px){
       /* HOTFIX MÓVIL (WA/Safari): evitar desktop comprimido */
       #confianza{overflow-x:hidden;overflow-y:visible;}


### PR DESCRIPTION
### Motivation
- Fix mobile rendering of the certifications block so badges do not overflow or get clipped on narrow viewports (WA/Safari and small phones). 

### Description
- Added an `@media (max-width: 420px)` block to `landing_venta.html` that forces `#confianza .certGrid` to `grid-template-columns: 1fr;`.
- Applied `min-width: 0` and `box-sizing: border-box` to `#confianza .certBadge`, `#confianza .certBadge *`, and `#confianza .certTxt` to prevent horizontal overflow and ensure proper sizing.
- Only `landing_venta.html` was modified; no UI/copy/structure changes were made.

### Testing
- Render verification: served the site with `python -m http.server 8000` and captured a mobile screenshot at `390x844` using Playwright, which completed successfully and produced `artifacts/landing_venta_mobile.png`.
- No automated unit tests were applicable for this static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e6f4e5c34832597cedf0cff1bf349)