### PR TITLE
Limit PDR logo fit CSS to landing_venta only

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1084,6 +1084,20 @@
       opacity:1 !important;
     }
 
+    /* PDR logo fit fix */
+    #confianza .certBadge img,
+    #confianza .certBadge .badgeImg,
+    #confianza .certBadge .logoImg {
+      width: 100% !important;
+      height: 100% !important;
+      object-fit: contain !important;   /* evita recorte, respeta proporción */
+      display: block !important;
+    }
+
+    #confianza .certBadge {
+      overflow: hidden !important;
+    }
+
     /* PDR */
     .pdrBoard{justify-content:center; gap:10px;}
     .pdrRow{display:flex;align-items:center;gap:10px}


### PR DESCRIPTION
### Motivation
- The PDR/Confianza badge CSS that enforces `object-fit: contain` was intended only for the sales landing and must not affect other landing pages.
- Ensure only `landing_venta.html` contains the PDR logo-fit adjustments while restoring other pages to their previous styling.

### Description
- Removed the PDR logo-fit CSS from `index.html` and `landing_corporativa.html` and kept the CSS in `landing_venta.html` only.  
- The retained rules in `landing_venta.html` target `#confianza .certBadge img`, `#confianza .certBadge .badgeImg`, and `#confianza .certBadge .logoImg` to set `width: 100%`, `height: 100%`, `object-fit: contain`, and `display: block`.  
- Added `overflow: hidden` to `#confianza .certBadge` in `landing_venta.html` to prevent visual overflow when badges are constrained.  
- The final change set modifies only `landing_venta.html`.

### Testing
- Started a local server with `python -m http.server 8000` and confirmed it served pages successfully (succeeded).  
- Rendered `landing_venta.html` with a Playwright script and saved a screenshot to `artifacts/pdr-logo-fit-landing-venta.png` to visually confirm the badge logos fit correctly (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e8001645c8325a0b7807dd3409c34)