### PR TITLE
Test metabólico v11: respuestas expertas + WhatsApp + gating (solo test)

### DIFF
--- a/assets/js/metab_expert.js
+++ b/assets/js/metab_expert.js
@@ -1,0 +1,283 @@
+(function () {
+  window.__metabExpertFinal = "v11";
+
+  const NAME_MIN_WORDS = 2;
+  const RESULT_REFRESH_DELAY_MS = 9000;
+  const MAX_SYMPTOMS = 4;
+  const WA_NUMBER = "17872321516";
+
+  function $(selector, root = document) {
+    return root.querySelector(selector);
+  }
+
+  function $all(selector, root = document) {
+    return Array.from(root.querySelectorAll(selector));
+  }
+
+  function cleanValue(value) {
+    return (value || "").trim();
+  }
+
+  function normalizeName(name) {
+    return cleanValue(name).replace(/\s+/g, " ");
+  }
+
+  function nameHasSurname(name) {
+    return normalizeName(name).split(" ").filter(Boolean).length >= NAME_MIN_WORDS;
+  }
+
+  function getLeadInputs() {
+    const fullNameInput = $("#nombreCompleto") || $("#fullName") || $("input[name=nombreCompleto]") || $("input[name=fullName]");
+    const nombreInput = $("#nombre") || $("input[name=nombre]");
+    const apellidoInput = $("#apellido") || $("input[name=apellido]");
+    const emailInput = $("#email") || $("input[name=email]");
+    const phoneInput =
+      $("#phone") ||
+      $("input[name=phone]") ||
+      $("input[name=tel]") ||
+      $("input[name=telefono]") ||
+      $("input[type=tel]");
+
+    return { fullNameInput, nombreInput, apellidoInput, emailInput, phoneInput };
+  }
+
+  function getLeadData() {
+    const { fullNameInput, nombreInput, apellidoInput, emailInput, phoneInput } = getLeadInputs();
+    let fullName = normalizeName(fullNameInput && fullNameInput.value);
+
+    if (!nameHasSurname(fullName)) {
+      const nombre = normalizeName(nombreInput && nombreInput.value);
+      const apellido = normalizeName(apellidoInput && apellidoInput.value);
+      if (nombre && apellido) {
+        fullName = normalizeName(`${nombre} ${apellido}`);
+      }
+    }
+
+    const email = cleanValue(emailInput && emailInput.value);
+    const phone = cleanValue(phoneInput && phoneInput.value);
+
+    const missing = [];
+    if (!nameHasSurname(fullName)) {
+      missing.push("Nombre y apellido");
+    }
+    if (!email) {
+      missing.push("Email");
+    }
+    if (!phone) {
+      missing.push("Teléfono");
+    }
+
+    return { fullName, email, phone, missing };
+  }
+
+  function getScore() {
+    const scoreNode = $("#scoreNum");
+    if (scoreNode) {
+      const parsed = parseInt(scoreNode.textContent, 10);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    const checks = $all('#checkList input[type="checkbox"]');
+    return checks.filter((c) => c.checked).length;
+  }
+
+  function getSymptoms() {
+    const checks = $all('#checkList input[type="checkbox"]');
+    const checked = checks.filter((c) => c.checked);
+    const labels = checked
+      .map((input) => {
+        const label = input.closest("label");
+        if (!label) {
+          return "";
+        }
+        const strong = label.querySelector("strong");
+        return cleanValue(strong ? strong.textContent : label.textContent);
+      })
+      .filter(Boolean);
+    return labels.slice(0, MAX_SYMPTOMS);
+  }
+
+  function levelForScore(score) {
+    if (score <= 2) {
+      return { label: "Leve", descriptor: "señales leves" };
+    }
+    if (score <= 5) {
+      return { label: "Moderado", descriptor: "señales moderadas" };
+    }
+    if (score <= 7) {
+      return { label: "Alto", descriptor: "señales altas" };
+    }
+    return { label: "Muy alto", descriptor: "señales muy altas" };
+  }
+
+  function buildMediterraneanBullets() {
+    return [
+      "Base vegetal: verduras en cada comida, legumbres 3-4 veces/semana y fruta entera diaria.",
+      "Grasas saludables: aceite de oliva extra virgen, aguacate, nueces y semillas.",
+      "Proteína limpia: pescado 2-3 veces/semana, huevo y yogur natural; limitar carnes procesadas.",
+      "Carbohidrato inteligente: integrales y porciones moderadas, priorizando fibra y saciedad.",
+    ];
+  }
+
+  function buildClinicalSuggestions(score) {
+    const tests = ["Glucosa en ayunas", "Insulina en ayunas", "HbA1c"];
+    if (score >= 6) {
+      tests.push("HOMA-IR (si aplica)");
+    } else {
+      tests.push("HOMA-IR (si aplica)");
+    }
+    return tests;
+  }
+
+  function buildResultText() {
+    const { fullName } = getLeadData();
+    const score = getScore();
+    const level = levelForScore(score);
+    const symptoms = getSymptoms();
+    const mediterranean = buildMediterraneanBullets();
+    const clinical = buildClinicalSuggestions(score);
+
+    const symptomsText = symptoms.length
+      ? symptoms.map((s) => `- ${s}`).join("\n")
+      : "- No marcaste síntomas en esta pasada.";
+
+    const mediterraneanText = mediterranean.map((b) => `• ${b}`).join("\n");
+    const clinicalText = clinical.map((t) => `- ${t}`).join("\n");
+
+    return [
+      `Hola ${fullName},`,
+      "",
+      `Nivel: ${level.label} (${level.descriptor}). Puntuación: ${score}. (Educativo, no diagnóstico).`,
+      "",
+      "Lo que marcaste:",
+      symptomsText,
+      "",
+      "Recomendación estilo Mediterráneo (Harvard):",
+      mediterraneanText,
+      "",
+      "Sugerencia clínica (educativo):",
+      clinicalText,
+      "",
+      "Responde METABOLISMO",
+      "",
+      "Educativo, no diagnóstico, no sustituye evaluación médica personalizada.",
+    ].join("\n");
+  }
+
+  function setResultText(text) {
+    const resultTarget = $("#lastResultText") || $("#resultText");
+    if (resultTarget) {
+      resultTarget.textContent = text;
+      return;
+    }
+    const resultBox = $(".resultBox") || $("#resultBox");
+    if (!resultBox) {
+      return;
+    }
+    const paragraphs = $all("p", resultBox);
+    const longParagraph = paragraphs.find((p) => cleanValue(p.textContent).length > 80);
+    if (longParagraph) {
+      longParagraph.textContent = text;
+    }
+  }
+
+  function showGatingMessage(missing) {
+    const message = `Para darte tu resultado necesitas completar: ${missing.join(", ")}.`;
+    setResultText(message);
+    window.lastResultText = "";
+  }
+
+  function applyExpertResult() {
+    const lead = getLeadData();
+    if (lead.missing.length) {
+      showGatingMessage(lead.missing);
+      return "";
+    }
+    const text = buildResultText();
+    setResultText(text);
+    window.lastResultText = text;
+    return text;
+  }
+
+  function ensureResultOverride() {
+    applyExpertResult();
+    setTimeout(() => applyExpertResult(), RESULT_REFRESH_DELAY_MS);
+  }
+
+  function interceptResultButton() {
+    const button = $("button[onclick=\"computeTest()\"]");
+    if (!button) {
+      return;
+    }
+
+    button.addEventListener(
+      "click",
+      (event) => {
+        const lead = getLeadData();
+        if (lead.missing.length) {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          showGatingMessage(lead.missing);
+          return;
+        }
+        setTimeout(() => ensureResultOverride(), 150);
+      },
+      true
+    );
+  }
+
+  function interceptWhatsAppButton() {
+    const button = $("button[onclick=\"sendResultToWhatsApp()\"]");
+    if (!button) {
+      return;
+    }
+
+    button.addEventListener(
+      "click",
+      (event) => {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        const lead = getLeadData();
+        if (lead.missing.length) {
+          alert(`Falta completar: ${lead.missing.join(", ")}.`);
+          showGatingMessage(lead.missing);
+          return;
+        }
+        const text = applyExpertResult() || buildResultText();
+        const url = `https://wa.me/${WA_NUMBER}?text=${encodeURIComponent(text)}`;
+        window.open(url, "_blank", "noopener");
+      },
+      true
+    );
+  }
+
+  function setupResultObserver() {
+    const target = $("#lastResultText") || $("#resultText") || $(".resultBox");
+    if (!target || !window.MutationObserver) {
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      const lead = getLeadData();
+      if (lead.missing.length) {
+        return;
+      }
+      applyExpertResult();
+    });
+
+    observer.observe(target, { childList: true, characterData: true, subtree: true });
+  }
+
+  function init() {
+    interceptResultButton();
+    interceptWhatsAppButton();
+    setupResultObserver();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/landing_venta.html
+++ b/landing_venta.html
@@ -2811,5 +2811,6 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
       }
     })();
   </script>
+  <script id="metab-test-personalization-v1" src="assets/js/metab_expert.js?v=METAB_V11"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Personalizar y mejorar exclusivamente las respuestas del “Test Metabólico Express (60s)” con mensaje humano y experto, gating por datos obligatorios y envío completo por WhatsApp al número indicado, sin modificar nada fuera del bloque del test.
- Implementar el override del resultado del test de forma robusta para ganarle al motor original cuando reescriba la vista.

### Description
- Añadido `assets/js/metab_expert.js` que expone `window.__metabExpertFinal = "v11"` y lee campos de lead en el orden solicitado (`nombreCompleto/fullName` o `nombre+apellido`, `email`, `phone`).
- El script calcula `score` desde `#scoreNum` o contando checkboxes, extrae top 3–4 síntomas, genera texto experto personalizado (nivel por score, "Lo que marcaste", bullets de recomendación estilo Mediterráneo (Harvard), sugerencia clínica, CTA y relevo de responsabilidad) y escribe el resultado en `#lastResultText` / `#resultText` o reemplaza el párrafo largo dentro del panel derecho.
- Implementa override robusto usando un `MutationObserver` y un re-escrito programado (~9s) tras el click en "Ver mi resultado" para asegurar que el texto experto permanezca; intercepta el click de "Enviar resultado por WhatsApp" para validar gating y abrir `https://wa.me/17872321516` con `encodeURIComponent(texto_resultado)`.
- Insertado loader limpio en `landing_venta.html` como `<script id="metab-test-personalization-v1" src="assets/js/metab_expert.js?v=METAB_V11"></script>` sin alterar ningún otro bloque del archivo.

### Testing
- Verifiqué que el diff incluye solo los dos archivos permitidos (`assets/js/metab_expert.js` y `landing_venta.html`) y que el loader fue agregado al final del HTML, lo cual fue exitoso.
- Inspeccioné el contenido del script y confirmé la presencia de la marca `window.__metabExpertFinal = "v11"` y las funciones claves (lectura de lead, cálculo de score, construcción de texto y hooks de interceptación), lo cual fue exitoso.
- Monté un servidor estático local e intenté una prueba E2E con Playwright para rellenar campos, marcar checks y capturar el resultado visual; la ejecución E2E falló por timeouts / problemas de localización en el entorno de CI y por tanto la validación automática completa no finalizó.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fe6dd4ffc83259f5f310813cd5bb7)