### PR TITLE
Actualizar bloque WhatsApp en landing_venta (texto y copy)

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1736,9 +1736,9 @@ a.card.trustTile .pdrBoard{
                 <div class="cardPad">
                   <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:14px;flex-wrap:wrap">
                     <div>
-                      <div style="font-weight:900;font-size:14px;letter-spacing:.2px">Entra por WhatsApp (rápido)</div>
+                      <div style="font-weight:900;font-size:14px;letter-spacing:.2px">Guarda tus datos y continúa al test</div>
                   <div style="color:rgba(71,85,105,.82);font-size:12px;margin-top:6px;line-height:1.35">
-                    Completa esto y te abre WhatsApp con el mensaje listo: <strong>METABOLISMO</strong>.
+                    Completa esto para guardar tus datos y avanzar directo al test.
                   </div>
                     </div>
                 <span class="badge">Datos mínimos · Sin estrés</span>
@@ -1770,13 +1770,7 @@ a.card.trustTile .pdrBoard{
                 </div>
 
                 <div class="formActions">
-                  <button class="btn btnSecondary" type="submit"><span>Abrir WhatsApp y enviar “METABOLISMO”</span></button>
-                </div>
-
-                <div class="consent">
-                  Al enviar, aceptas que te contactemos por WhatsApp para darte orientación educativa y seguimiento.
-                  <strong>No es diagnóstico médico.</strong>
-                  <br/>Al enviar aceptas que te contactemos por email/WhatsApp. Puedes solicitar baja.
+                  <button class="btn btnSecondary" type="submit"><span>Guardar y seguir</span></button>
                 </div>
 
                 <div class="consent" id="leadStatus" role="status" aria-live="polite" style="display:none"></div>


### PR DESCRIPTION
### Motivation
- Cambiar el bloque "Entra por WhatsApp (rápido)" para que indique el guardado de datos y la continuación al test, eliminando la mención al mensaje `METABOLISMO` y contenido redundante.

### Description
- Modifiqué el título del bloque a "Guarda tus datos y continúa al test" en `landing_venta.html`.
- Reescribí el subtítulo para eliminar la referencia a `METABOLISMO` y explicar que el formulario guarda los datos y avanza al test.
- Cambié el texto del botón a "Guardar y seguir".
- Eliminé los dos párrafos de copy/consentimiento redundantes que estaban inmediatamente debajo del botón, sin tocar otras secciones ni estilos.

### Testing
- Serví los archivos con `python -m http.server 8000` y ejecuté un script de Playwright para cargar `http://localhost:8000/landing_venta.html` y capturar una captura de pantalla, la cual se generó correctamente.
- No se ejecutaron pruebas unitarias adicionales porque es un cambio estático de contenido.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff4e889688325bbdf608c3688848e)