### PR TITLE
Make “Guardar y seguir” a botón no-submit y add save-and-continue handler

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1770,13 +1770,122 @@ a.card.trustTile .pdrBoard{
                 </div>
 
                 <div class="formActions">
-                  <button class="btn btnSecondary" type="submit"><span>Guardar y seguir</span></button>
+                  <button class="btn btnSecondary" type="button" id="saveContinueBtn"><span>Guardar y seguir</span></button>
                 </div>
 
-                <div class="consent" id="leadStatus" role="status" aria-live="polite" style="display:none"></div>
+                <div class="consent" id="saveContinueMsg" role="status" aria-live="polite" style="display:none"></div>
               </form>
             </div>
           </div>
+          <script id="save-continue-handler-v1">
+            (() => {
+              const formEl = document.getElementById("leadForm");
+              const btn = document.getElementById("saveContinueBtn");
+              const msgEl = document.getElementById("saveContinueMsg");
+              if (!formEl || !btn || !msgEl) {
+                return;
+              }
+
+              const nameEl = document.getElementById("name");
+              const cityEl = document.getElementById("city");
+              const emailEl = document.getElementById("email");
+              const phoneEl = document.getElementById("phone");
+              const testSection = document.getElementById("test");
+
+              const sanitize = (value, limit) => {
+                const v = (value || "").toString().trim();
+                if (!limit) return v;
+                return v.slice(0, limit);
+              };
+
+              const setMsg = (text, isError) => {
+                msgEl.style.display = text ? "block" : "none";
+                msgEl.style.color = isError ? "rgba(239,68,68,.95)" : "rgba(34,197,94,.95)";
+                msgEl.textContent = text || "";
+              };
+
+              const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+              const getMissingFields = (data) => {
+                const missing = [];
+                const nameParts = data.name.split(/\s+/).filter(Boolean);
+                if (nameParts.length < 2) {
+                  missing.push("Nombre y apellido");
+                }
+                if (!emailRegex.test(data.email)) {
+                  missing.push("Email");
+                }
+                const phoneDigits = data.phone.replace(/\D+/g, "");
+                if (phoneDigits.length < 10) {
+                  missing.push("Teléfono");
+                }
+                return missing;
+              };
+
+              const handleSave = async () => {
+                const data = {
+                  name: sanitize(nameEl?.value, 120),
+                  city: sanitize(cityEl?.value, 120),
+                  email: sanitize(emailEl?.value, 160),
+                  phone: sanitize(phoneEl?.value, 40),
+                  ts: new Date().toISOString()
+                };
+
+                const missing = getMissingFields(data);
+                if (missing.length) {
+                  setMsg(`Falta: ${missing.join(" / ")}`, true);
+                  return;
+                }
+
+                try {
+                  localStorage.setItem(
+                    "bn_lead",
+                    JSON.stringify({
+                      name: data.name,
+                      city: data.city,
+                      email: data.email,
+                      phone: data.phone,
+                      ts: data.ts
+                    })
+                  );
+                } catch (_) {}
+
+                setMsg("✅ Guardado. Bajando al test…", false);
+
+                try {
+                  const body = {
+                    name: data.name,
+                    city: data.city,
+                    email: data.email,
+                    phone: data.phone,
+                    ts: data.ts,
+                    hp: document.getElementById("website")?.value || ""
+                  };
+                  const resp = await fetch("api/lead.php", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(body)
+                  });
+                  await resp.json().catch(() => null);
+                } catch (_) {}
+
+                if (testSection) {
+                  testSection.scrollIntoView({ behavior: "smooth", block: "start" });
+                }
+              };
+
+              btn.addEventListener("click", (e) => {
+                e.preventDefault();
+                handleSave();
+              });
+
+              formEl.addEventListener("submit", (e) => {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                handleSave();
+              });
+            })();
+          </script>
 
           <p class="fine">
             Nota: Este contenido es educativo y no sustituye una evaluación médica. Si tienes diabetes, embarazo/lactancia,


### PR DESCRIPTION
### Motivation
- Reemplazar el comportamiento actual de envío por WhatsApp con una interacción que guarde los datos localmente y permita continuar al test sin abrir nuevos flujos obligatorios. 
- Evitar que el botón sea un `submit` para prevenir envíos automáticos y permitir validación/guardado controlado en cliente. 
- Mostrar mensajes específicos de error o éxito en un contenedor dedicado en lugar de un mensaje genérico.

### Description
- Cambié el botón de `type="submit"` a `type="button"` y le asigné `id="saveContinueBtn"` en el bloque de datos.  
- Reemplacé el contenedor `leadStatus` por un nuevo contenedor de mensaje con `id="saveContinueMsg"`.  
- Inserté un script inline con `id="save-continue-handler-v1"` que valida: nombre y apellido (al menos 2 palabras), email con regex, y teléfono con al menos 10 dígitos.  
- El script guarda los datos en `localStorage` bajo la clave `bn_lead` con `{name, city, email, phone, ts}`, intenta un `POST` no bloqueante a `api/lead.php`, muestra el mensaje verde `✅ Guardado. Bajando al test…` y hace scroll suave al bloque `#test`; si faltan campos muestra un mensaje rojo como `Falta: Nombre y apellido / Email / Teléfono`.

### Testing
- Intenté capturar la página con Playwright para validar visualmente el bloque y la presencia del script, pero la ejecución del navegador falló (crash/timeout) y la prueba automatizada no completó correctamente.  
- No se ejecutaron otras pruebas automatizadas; el cambio fue verificado estáticamente en el archivo `landing_venta.html` y el script insertado aparece en su ubicación esperada.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697001ac35348325b4e9e1e89ceea822)