### PR TITLE
Ensure lead saved to localStorage and add robust scroll-to-test behavior

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1790,7 +1790,25 @@ a.card.trustTile .pdrBoard{
               const cityEl = document.getElementById("city");
               const emailEl = document.getElementById("email");
               const phoneEl = document.getElementById("phone");
-              const testSection = document.getElementById("test");
+              const findTestTarget = () => {
+                const headings = Array.from(document.querySelectorAll("h1,h2,h3,h4,h5,h6"));
+                const metabHeading = headings.find((heading) =>
+                  heading.textContent?.toLowerCase().includes("test metabólico")
+                );
+                if (metabHeading) {
+                  return (
+                    metabHeading.closest("section") ||
+                    metabHeading.closest("div") ||
+                    metabHeading
+                  );
+                }
+
+                return (
+                  document.getElementById("metabTest") ||
+                  document.getElementById("testMetabolico") ||
+                  document.getElementById("test")
+                );
+              };
 
               const sanitize = (value, limit) => {
                 const v = (value || "").toString().trim();
@@ -1850,7 +1868,14 @@ a.card.trustTile .pdrBoard{
                   );
                 } catch (_) {}
 
-                setMsg("✅ Guardado. Bajando al test…", false);
+                let storedLead = "";
+                try {
+                  storedLead = localStorage.getItem("bn_lead") || "";
+                } catch (_) {}
+
+                if (storedLead) {
+                  setMsg("✅ Guardado. Bajando al test…", false);
+                }
 
                 try {
                   const body = {
@@ -1869,9 +1894,15 @@ a.card.trustTile .pdrBoard{
                   await resp.json().catch(() => null);
                 } catch (_) {}
 
-                if (testSection) {
-                  testSection.scrollIntoView({ behavior: "smooth", block: "start" });
+                const testTarget = findTestTarget();
+                if (testTarget) {
+                  testTarget.scrollIntoView({ behavior: "smooth", block: "start" });
+                  return;
                 }
+
+                const fallbackScroll = Math.round(document.documentElement.scrollHeight * 0.4);
+                window.scrollTo({ top: fallbackScroll, behavior: "smooth" });
+                setMsg("✅ Guardado. Baja un poco para ver el test.", false);
               };
 
               btn.addEventListener("click", (e) => {


### PR DESCRIPTION
### Motivation
- Guarantee the lead data is persisted to `localStorage` before attempting the network request so the page can recover state if the fetch fails.
- Provide clear UX feedback after saving, showing a success message when the data is actually stored.
- Make scrolling to the test section more resilient by locating the real test container via heading or multiple common IDs and offering a fallback when not found.

### Description
- In `landing_venta.html` added `findTestTarget()` which locates a test container by searching headings that include "Test Metabólico" and then falls back to `#metabTest`, `#testMetabolico`, or `#test`.
- Ensure `localStorage.setItem("bn_lead", ...)` runs before the fetch, then immediately re-read `localStorage.getItem("bn_lead")` and show `"✅ Guardado. Bajando al test…"` when present.
- Replace the previous direct scroll to `#test` with a call to `findTestTarget()` to `scrollIntoView` when found; otherwise scroll to 40% of the document height and show `"✅ Guardado. Baja un poco para ver el test."`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69700cb75f0c8325970ad2679e3bda23)