### PR TITLE
Fix metabolic test lead gating: read fresh lead, normalize name and add debug banner

### DIFF
--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1859,6 +1859,7 @@ a.card.trustTile .pdrBoard{
                   localStorage.setItem(
                     "bn_lead",
                     JSON.stringify({
+                      fullName: data.name,
                       name: data.name,
                       city: data.city,
                       email: data.email,


### PR DESCRIPTION
### Motivation
- Ensure the metabolic test always detects the lead saved by “Guardar y seguir” so clicking “Ver mi resultado” correctly renders the expert result when a full name is present. 
- Avoid aggressive timers and avoid clearing or removing test UI when gating fails; surface a clear message in the result panel instead. 
- Provide a lightweight debug banner (without DevTools) when `debug=1` to help diagnose which localStorage key and name were used.

### Description
- Implemented `getStoredLead`, `buildFullNameFromLead` and `getLeadFresh` in `assets/js/metab_expert.js` to read localStorage on each result click from keys in order `bn_lead`, `bnLead`, `lead`, JSON-parse safely, normalize `fullName` from several possible fields, combine `nombre` + `apellido` when needed, collapse spaces and trim, and validate name has >= 2 words. 
- Replaced prior input-based gating with `getLeadFresh()` usage across the result flow so gating checks the freshest stored lead; the gate only requires `Nombre y apellido` and writes a clear panel message: “Para darte tu resultado necesitas completar: Nombre y apellido.”
- Removed aggressive refresh timers and ensured the click handler on the `computeTest()` button directly calls the expert result flow and runs `maybeRenderDebugInfo()` when `debug=1` to show: `Lead detectado: <fullName> | key usada: <bn_lead/bnLead/lead> | v: <marker>` above the result panel. 
- Limited DOM observation to the result panel only and render debug info there using `getResultPanel()` and a single injected `.metab-debug-lead` element. 
- Minimal change in `landing_venta.html`: include `fullName: data.name` when persisting `bn_lead` so the stored object contains a normalized `fullName` for the gating logic.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710af793b48325a7040f7949892e59)