### PR TITLE
fix-gate-root-sync-v1

### DIFF
--- a/index.html
+++ b/index.html
@@ -1762,51 +1762,94 @@ a.card.trustTile .pdrBoard{
               </div>
                   
 
-              <form id="leadForm" autocomplete="on">
+              <div id="leadGate">
                 <div style="position:absolute;left:-9999px;opacity:0;pointer-events:none" aria-hidden="true">
                   <label for="website">Sitio web</label>
                   <input id="website" name="website" tabindex="-1" autocomplete="off" />
                 </div>
-                <div class="formGrid" style="margin-top:14px">
-                  <div>
-                    <label for="name">Nombre</label>
-                    <input id="name" name="name" placeholder="Tu nombre" required />
-                  </div>
-                  <div>
-                    <label for="city">Ciudad</label>
-                    <input id="city" name="city" placeholder="Monterrey / San Nicolás / Guadalupe…" required />
-                  </div>
-                  <div>
-                    <label for="email">Email</label>
-                    <input id="email" name="email" type="email" placeholder="tucorreo@email.com" required />
-                  </div>
-                  <div>
-                    <label for="phone">Teléfono (WhatsApp)</label>
-                    <input id="phone" name="phone" inputmode="tel" placeholder="+52 81… / +1 787…" required />
+
+                <div id="leadWelcome" style="display:none;margin-top:14px">
+                  <div style="font-weight:700;margin-bottom:10px">✅ Bienvenido de vuelta. Solo confirma tu email para continuar.</div>
+                  <div class="formActions">
+                    <button class="btn btnSecondary" type="button" id="leadContinueBtn"><span>Continuar al test</span></button>
+                    <a class="btn btnGhost" href="#" id="leadChangeEmail">Cambiar email</a>
                   </div>
                 </div>
 
-                <div class="formActions">
-                  <button class="btn btnSecondary" type="button" id="saveContinueBtn"><span>Guardar y seguir</span></button>
+                <div id="leadSelector" style="display:none;margin-top:14px">
+                  <div style="font-weight:700;margin-bottom:10px">¿Es tu primera vez con nosotros?</div>
+                  <div class="formActions">
+                    <button class="btn btnSecondary" type="button" id="leadFirstBtn"><span>Es mi primera vez</span></button>
+                    <button class="btn btnGhost" type="button" id="leadReturningBtn"><span>Ya estoy registrado</span></button>
+                  </div>
                 </div>
 
-                <div class="consent" id="saveContinueMsg" role="status" aria-live="polite" style="display:none"></div>
-              </form>
+                <form id="leadEmailForm" autocomplete="on" style="display:none;margin-top:14px">
+                  <div class="formGrid">
+                    <div>
+                      <label for="leadEmail">Email</label>
+                      <input id="leadEmail" name="email" type="email" placeholder="tucorreo@email.com" required />
+                    </div>
+                  </div>
+                  <div class="formActions">
+                    <button class="btn btnSecondary" type="submit" id="leadEmailBtn"><span>Continuar</span></button>
+                  </div>
+                </form>
+
+                <form id="leadFullForm" autocomplete="on" style="display:none;margin-top:14px">
+                  <div class="formGrid">
+                    <div>
+                      <label for="nombre">Nombre</label>
+                      <input id="nombre" name="nombre" placeholder="Tu nombre" required />
+                    </div>
+                    <div>
+                      <label for="apellido">Apellido</label>
+                      <input id="apellido" name="apellido" placeholder="Tu apellido" required />
+                    </div>
+                    <div>
+                      <label for="leadFullEmail">Email</label>
+                      <input id="leadFullEmail" name="email" type="email" placeholder="tucorreo@email.com" required />
+                    </div>
+                    <div>
+                      <label for="phone">Teléfono (WhatsApp)</label>
+                      <input id="phone" name="phone" inputmode="tel" placeholder="+52 81… / +1 787…" required />
+                    </div>
+                    <div>
+                      <label for="city">Ciudad/Estado</label>
+                      <input id="city" name="city" placeholder="Monterrey / San Nicolás / Guadalupe…" required />
+                    </div>
+                  </div>
+                  <div class="formActions">
+                    <button class="btn btnSecondary" type="submit" id="leadFullBtn"><span>Guardar y seguir</span></button>
+                  </div>
+                </form>
+
+                <div class="consent" id="leadGateMsg" role="status" aria-live="polite" style="display:none"></div>
+              </div>
             </div>
           </div>
           <script id="save-continue-handler-v1">
             (() => {
-              const formEl = document.getElementById("leadForm");
-              const btn = document.getElementById("saveContinueBtn");
-              const msgEl = document.getElementById("saveContinueMsg");
-              if (!formEl || !btn || !msgEl) {
+              const gateEl = document.getElementById("leadGate");
+              const welcomeEl = document.getElementById("leadWelcome");
+              const selectorEl = document.getElementById("leadSelector");
+              const emailForm = document.getElementById("leadEmailForm");
+              const fullForm = document.getElementById("leadFullForm");
+              const emailInput = document.getElementById("leadEmail");
+              const emailFullInput = document.getElementById("leadFullEmail");
+              const firstNameEl = document.getElementById("nombre");
+              const lastNameEl = document.getElementById("apellido");
+              const cityEl = document.getElementById("city");
+              const phoneEl = document.getElementById("phone");
+              const continueBtn = document.getElementById("leadContinueBtn");
+              const changeEmailBtn = document.getElementById("leadChangeEmail");
+              const firstBtn = document.getElementById("leadFirstBtn");
+              const returningBtn = document.getElementById("leadReturningBtn");
+              const msgEl = document.getElementById("leadGateMsg");
+              if (!gateEl || !emailForm || !fullForm || !msgEl) {
                 return;
               }
 
-              const nameEl = document.getElementById("name");
-              const cityEl = document.getElementById("city");
-              const emailEl = document.getElementById("email");
-              const phoneEl = document.getElementById("phone");
               const findTestTarget = () => {
                 const headings = Array.from(document.querySelectorAll("h1,h2,h3,h4,h5,h6"));
                 const metabHeading = headings.find((heading) =>
@@ -1841,98 +1884,225 @@ a.card.trustTile .pdrBoard{
 
               const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-              const getMissingFields = (data) => {
-                const missing = [];
-                const nameParts = data.name.split(/\s+/).filter(Boolean);
-                if (nameParts.length < 2) {
-                  missing.push("Nombre y apellido");
+              const showState = (state) => {
+                if (welcomeEl) {
+                  welcomeEl.style.display = state === "welcome" ? "block" : "none";
                 }
-                if (!emailRegex.test(data.email)) {
-                  missing.push("Email");
+                if (selectorEl) {
+                  selectorEl.style.display = state === "selector" ? "block" : "none";
                 }
-                const phoneDigits = data.phone.replace(/\D+/g, "");
-                if (phoneDigits.length < 10) {
-                  missing.push("Teléfono");
-                }
-                return missing;
+                emailForm.style.display = state === "email" ? "block" : "none";
+                fullForm.style.display = state === "full" ? "block" : "none";
               };
 
-              const handleSave = async () => {
-                const data = {
-                  name: sanitize(nameEl?.value, 120),
-                  city: sanitize(cityEl?.value, 120),
-                  email: sanitize(emailEl?.value, 160),
-                  phone: sanitize(phoneEl?.value, 40),
-                  ts: new Date().toISOString()
-                };
-
-                const missing = getMissingFields(data);
-                if (missing.length) {
-                  setMsg(`Falta: ${missing.join(" / ")}`, true);
-                  return;
-                }
-
-                try {
-                  localStorage.setItem(
-                    "bn_lead",
-                    JSON.stringify({
-                      fullName: data.name,
-                      name: data.name,
-                      city: data.city,
-                      email: data.email,
-                      phone: data.phone,
-                      ts: data.ts
-                    })
-                  );
-                } catch (_) {}
-
-                let storedLead = "";
-                try {
-                  storedLead = localStorage.getItem("bn_lead") || "";
-                } catch (_) {}
-
-                if (storedLead) {
-                  setMsg("✅ Guardado. Bajando al test…", false);
-                }
-
-                try {
-                  const body = {
-                    name: data.name,
-                    city: data.city,
-                    email: data.email,
-                    phone: data.phone,
-                    ts: data.ts,
-                    hp: document.getElementById("website")?.value || ""
-                  };
-                  const resp = await fetch("api/lead.php", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify(body)
-                  });
-                  await resp.json().catch(() => null);
-                } catch (_) {}
-
+              const scrollToTest = () => {
                 const testTarget = findTestTarget();
                 if (testTarget) {
                   testTarget.scrollIntoView({ behavior: "smooth", block: "start" });
                   return;
                 }
-
                 const fallbackScroll = Math.round(document.documentElement.scrollHeight * 0.4);
                 window.scrollTo({ top: fallbackScroll, behavior: "smooth" });
-                setMsg("✅ Guardado. Baja un poco para ver el test.", false);
               };
 
-              btn.addEventListener("click", (e) => {
+              const saveAuth = (email, leadData = {}) => {
+                try {
+                  localStorage.setItem("bn_ok", "1");
+                  localStorage.setItem("bn_email", email);
+                  localStorage.setItem(
+                    "bn_lead",
+                    JSON.stringify({
+                      ...leadData,
+                      email,
+                      ts: new Date().toISOString()
+                    })
+                  );
+                } catch (_) {}
+              };
+
+              const clearAuth = () => {
+                try {
+                  localStorage.removeItem("bn_ok");
+                  localStorage.removeItem("bn_email");
+                } catch (_) {}
+              };
+
+              const getStoredAuth = () => {
+                try {
+                  return {
+                    ok: localStorage.getItem("bn_ok") === "1",
+                    email: localStorage.getItem("bn_email") || ""
+                  };
+                } catch (_) {
+                  return { ok: false, email: "" };
+                }
+              };
+
+              const setLoading = (btnEl, loading) => {
+                if (!btnEl) return;
+                btnEl.setAttribute("aria-busy", loading ? "true" : "false");
+                btnEl.disabled = !!loading;
+              };
+
+              const handleEmailCheck = async () => {
+                const email = sanitize(emailInput?.value, 160).toLowerCase();
+                if (!emailRegex.test(email)) {
+                  setMsg("Ingresa un email válido.", true);
+                  return;
+                }
+                setMsg("", false);
+                setLoading(document.getElementById("leadEmailBtn"), true);
+                try {
+                  const resp = await fetch("api/lead.php", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                      action: "check",
+                      email,
+                      hp: document.getElementById("website")?.value || ""
+                    })
+                  });
+                  const data = await resp.json();
+                  if (!data || !data.ok) {
+                    setMsg("No pudimos validar el email. Intenta de nuevo.", true);
+                    return;
+                  }
+                  if (data.exists) {
+                    saveAuth(email, { email });
+                    showState("welcome");
+                    setMsg("✅ Email confirmado. Bajando al test…", false);
+                    scrollToTest();
+                    return;
+                  }
+                  if (emailFullInput) {
+                    emailFullInput.value = email;
+                  }
+                  showState("full");
+                  setMsg("No encontramos ese email. Completa tus datos para continuar.", true);
+                } catch (_) {
+                  setMsg("No pudimos conectar. Intenta de nuevo.", true);
+                } finally {
+                  setLoading(document.getElementById("leadEmailBtn"), false);
+                }
+              };
+
+              const handleFullSave = async () => {
+                const email = sanitize(emailFullInput?.value, 160).toLowerCase();
+                const firstName = sanitize(firstNameEl?.value, 80);
+                const lastName = sanitize(lastNameEl?.value, 80);
+                const city = sanitize(cityEl?.value, 120);
+                const phone = sanitize(phoneEl?.value, 40);
+                const missing = [];
+                if (!firstName) missing.push("Nombre");
+                if (!lastName) missing.push("Apellido");
+                if (!emailRegex.test(email)) missing.push("Email");
+                const phoneDigits = phone.replace(/\D+/g, "");
+                if (phoneDigits.length < 10) missing.push("Teléfono");
+                if (!city) missing.push("Ciudad/Estado");
+                if (missing.length) {
+                  setMsg(`Falta: ${missing.join(" / ")}`, true);
+                  return;
+                }
+                setLoading(document.getElementById("leadFullBtn"), true);
+                try {
+                  const payload = {
+                    action: "upsert",
+                    name: `${firstName} ${lastName}`.trim(),
+                    first_name: firstName,
+                    last_name: lastName,
+                    city,
+                    email,
+                    phone,
+                    hp: document.getElementById("website")?.value || ""
+                  };
+                  const resp = await fetch("api/lead.php", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(payload)
+                  });
+                  const data = await resp.json();
+                  if (!data || !data.ok) {
+                    setMsg("No pudimos guardar tus datos. Intenta de nuevo.", true);
+                    return;
+                  }
+                  saveAuth(email, {
+                    fullName: `${firstName} ${lastName}`.trim(),
+                    nombre: firstName,
+                    apellido: lastName,
+                    name: `${firstName} ${lastName}`.trim(),
+                    city,
+                    phone
+                  });
+                  showState("welcome");
+                  setMsg("✅ Guardado. Bajando al test…", false);
+                  scrollToTest();
+                } catch (_) {
+                  setMsg("No pudimos conectar. Intenta de nuevo.", true);
+                } finally {
+                  setLoading(document.getElementById("leadFullBtn"), false);
+                }
+              };
+
+              const auth = getStoredAuth();
+              if (auth.ok && auth.email) {
+                showState("welcome");
+              } else {
+                showState("selector");
+              }
+
+              emailForm.addEventListener("submit", (e) => {
                 e.preventDefault();
-                handleSave();
+                handleEmailCheck();
               });
 
-              formEl.addEventListener("submit", (e) => {
+              fullForm.addEventListener("submit", (e) => {
                 e.preventDefault();
-                e.stopImmediatePropagation();
-                handleSave();
+                handleFullSave();
               });
+
+              if (firstBtn) {
+                firstBtn.addEventListener("click", (e) => {
+                  e.preventDefault();
+                  showState("full");
+                  setMsg("", false);
+                  if (emailFullInput) {
+                    emailFullInput.value = "";
+                  }
+                });
+              }
+
+              if (returningBtn) {
+                returningBtn.addEventListener("click", (e) => {
+                  e.preventDefault();
+                  showState("email");
+                  setMsg("", false);
+                  if (emailInput) {
+                    emailInput.value = "";
+                  }
+                });
+              }
+
+              if (continueBtn) {
+                continueBtn.addEventListener("click", (e) => {
+                  e.preventDefault();
+                  scrollToTest();
+                });
+              }
+
+              if (changeEmailBtn) {
+                changeEmailBtn.addEventListener("click", (e) => {
+                  e.preventDefault();
+                  clearAuth();
+                  if (emailInput) {
+                    emailInput.value = "";
+                  }
+                  if (emailFullInput) {
+                    emailFullInput.value = "";
+                  }
+                  showState("selector");
+                  setMsg("", false);
+                });
+              }
             })();
           </script>
 

--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1769,14 +1769,22 @@ a.card.trustTile .pdrBoard{
                 </div>
 
                 <div id="leadWelcome" style="display:none;margin-top:14px">
-                  <div style="font-weight:700;margin-bottom:10px">✅ Bienvenido de vuelta. Tu email ya está registrado.</div>
+                  <div style="font-weight:700;margin-bottom:10px">✅ Bienvenido de vuelta. Solo confirma tu email para continuar.</div>
                   <div class="formActions">
                     <button class="btn btnSecondary" type="button" id="leadContinueBtn"><span>Continuar al test</span></button>
                     <a class="btn btnGhost" href="#" id="leadChangeEmail">Cambiar email</a>
                   </div>
                 </div>
 
-                <form id="leadEmailForm" autocomplete="on" style="margin-top:14px">
+                <div id="leadSelector" style="display:none;margin-top:14px">
+                  <div style="font-weight:700;margin-bottom:10px">¿Es tu primera vez con nosotros?</div>
+                  <div class="formActions">
+                    <button class="btn btnSecondary" type="button" id="leadFirstBtn"><span>Es mi primera vez</span></button>
+                    <button class="btn btnGhost" type="button" id="leadReturningBtn"><span>Ya estoy registrado</span></button>
+                  </div>
+                </div>
+
+                <form id="leadEmailForm" autocomplete="on" style="display:none;margin-top:14px">
                   <div class="formGrid">
                     <div>
                       <label for="leadEmail">Email</label>
@@ -1799,6 +1807,10 @@ a.card.trustTile .pdrBoard{
                       <input id="apellido" name="apellido" placeholder="Tu apellido" required />
                     </div>
                     <div>
+                      <label for="leadFullEmail">Email</label>
+                      <input id="leadFullEmail" name="email" type="email" placeholder="tucorreo@email.com" required />
+                    </div>
+                    <div>
                       <label for="phone">Teléfono (WhatsApp)</label>
                       <input id="phone" name="phone" inputmode="tel" placeholder="+52 81… / +1 787…" required />
                     </div>
@@ -1807,7 +1819,6 @@ a.card.trustTile .pdrBoard{
                       <input id="city" name="city" placeholder="Monterrey / San Nicolás / Guadalupe…" required />
                     </div>
                   </div>
-                  <input id="leadEmailHidden" name="email" type="hidden" />
                   <div class="formActions">
                     <button class="btn btnSecondary" type="submit" id="leadFullBtn"><span>Guardar y seguir</span></button>
                   </div>
@@ -1821,16 +1832,19 @@ a.card.trustTile .pdrBoard{
             (() => {
               const gateEl = document.getElementById("leadGate");
               const welcomeEl = document.getElementById("leadWelcome");
+              const selectorEl = document.getElementById("leadSelector");
               const emailForm = document.getElementById("leadEmailForm");
               const fullForm = document.getElementById("leadFullForm");
               const emailInput = document.getElementById("leadEmail");
-              const emailHidden = document.getElementById("leadEmailHidden");
+              const emailFullInput = document.getElementById("leadFullEmail");
               const firstNameEl = document.getElementById("nombre");
               const lastNameEl = document.getElementById("apellido");
               const cityEl = document.getElementById("city");
               const phoneEl = document.getElementById("phone");
               const continueBtn = document.getElementById("leadContinueBtn");
               const changeEmailBtn = document.getElementById("leadChangeEmail");
+              const firstBtn = document.getElementById("leadFirstBtn");
+              const returningBtn = document.getElementById("leadReturningBtn");
               const msgEl = document.getElementById("leadGateMsg");
               if (!gateEl || !emailForm || !fullForm || !msgEl) {
                 return;
@@ -1873,6 +1887,9 @@ a.card.trustTile .pdrBoard{
               const showState = (state) => {
                 if (welcomeEl) {
                   welcomeEl.style.display = state === "welcome" ? "block" : "none";
+                }
+                if (selectorEl) {
+                  selectorEl.style.display = state === "selector" ? "block" : "none";
                 }
                 emailForm.style.display = state === "email" ? "block" : "none";
                 fullForm.style.display = state === "full" ? "block" : "none";
@@ -1953,13 +1970,15 @@ a.card.trustTile .pdrBoard{
                   if (data.exists) {
                     saveAuth(email, { email });
                     showState("welcome");
-                    setMsg("✅ Email validado. Puedes continuar.", false);
+                    setMsg("✅ Email confirmado. Bajando al test…", false);
                     scrollToTest();
                     return;
                   }
-                  emailHidden.value = email;
+                  if (emailFullInput) {
+                    emailFullInput.value = email;
+                  }
                   showState("full");
-                  setMsg("Completa tus datos para continuar.", false);
+                  setMsg("No encontramos ese email. Completa tus datos para continuar.", true);
                 } catch (_) {
                   setMsg("No pudimos conectar. Intenta de nuevo.", true);
                 } finally {
@@ -1968,7 +1987,7 @@ a.card.trustTile .pdrBoard{
               };
 
               const handleFullSave = async () => {
-                const email = sanitize(emailHidden?.value, 160).toLowerCase();
+                const email = sanitize(emailFullInput?.value, 160).toLowerCase();
                 const firstName = sanitize(firstNameEl?.value, 80);
                 const lastName = sanitize(lastNameEl?.value, 80);
                 const city = sanitize(cityEl?.value, 120);
@@ -2028,7 +2047,7 @@ a.card.trustTile .pdrBoard{
               if (auth.ok && auth.email) {
                 showState("welcome");
               } else {
-                showState("email");
+                showState("selector");
               }
 
               emailForm.addEventListener("submit", (e) => {
@@ -2040,6 +2059,28 @@ a.card.trustTile .pdrBoard{
                 e.preventDefault();
                 handleFullSave();
               });
+
+              if (firstBtn) {
+                firstBtn.addEventListener("click", (e) => {
+                  e.preventDefault();
+                  showState("full");
+                  setMsg("", false);
+                  if (emailFullInput) {
+                    emailFullInput.value = "";
+                  }
+                });
+              }
+
+              if (returningBtn) {
+                returningBtn.addEventListener("click", (e) => {
+                  e.preventDefault();
+                  showState("email");
+                  setMsg("", false);
+                  if (emailInput) {
+                    emailInput.value = "";
+                  }
+                });
+              }
 
               if (continueBtn) {
                 continueBtn.addEventListener("click", (e) => {
@@ -2055,7 +2096,10 @@ a.card.trustTile .pdrBoard{
                   if (emailInput) {
                     emailInput.value = "";
                   }
-                  showState("email");
+                  if (emailFullInput) {
+                    emailFullInput.value = "";
+                  }
+                  showState("selector");
                   setMsg("", false);
                 });
               }


### PR DESCRIPTION
### Motivation
- The root page was showing a broken "solo email" gate and was desynchronized from `landing_venta.html`, causing a bad UX and potential lead loss; the gate must support first-time vs returning flows and keep local session state consistent.
- Keep the same gate behavior (email-check + full registration) across both pages while preserving the existing "Test Metabólico Express" block and not touching server API or unrelated modules.

### Description
- Replaced the simple root capture form with a unified `#leadGate` block (HTML + inline JS) that matches `landing_venta.html` so both pages are identical.
- Added a selector state with two buttons: "Es mi primera vez" (shows the full form) and "Ya estoy registrado" (shows email-only form), plus a welcome state for returning users with message and actions.
- Implemented client-side logic: `showState`, `handleEmailCheck` (POST `action=check` to `api/lead.php`), `handleFullSave` (POST `action=upsert`), `saveAuth` / `clearAuth` / `getStoredAuth` updating `localStorage` keys `bn_ok`, `bn_email`, `bn_lead`, form validation, and scrolling to the test target; all inline JS is now the same in `index.html` and `landing_venta.html`.
- Kept the "Test Metabólico Express" block and layout/copy untouched and did not modify `api/lead.php` or other files.

### Testing
- Verified file diffs and synchronization with text search and `diff` to ensure the same gate HTML/JS is present in both files and that welcome text was updated; these checks succeeded.
- Launched a local static server (`python -m http.server 8000`) and executed a headless Playwright script to load `index.html` and capture a screenshot of the gate; the screenshot artifact was produced successfully.
- Committed the changes and created the PR `fix-gate-root-sync-v1`; all automated verification steps above completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697398106078832598d528bd814fcd3d)