### PR TITLE
fix-api-connectivity-v1

### DIFF
--- a/index.html
+++ b/index.html
@@ -1953,7 +1953,7 @@ a.card.trustTile .pdrBoard{
                 setMsg("", false);
                 setLoading(document.getElementById("leadEmailBtn"), true);
                 try {
-                  const resp = await fetch("api/lead.php", {
+                  const resp = await fetch("/api/lead.php", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({
@@ -1964,7 +1964,7 @@ a.card.trustTile .pdrBoard{
                   });
                   const data = await resp.json();
                   if (!data || !data.ok) {
-                    setMsg("No pudimos validar el email. Intenta de nuevo.", true);
+                    setMsg("No pudimos conectar. Intenta de nuevo en 10 segundos.", true);
                     return;
                   }
                   if (data.exists) {
@@ -1978,9 +1978,9 @@ a.card.trustTile .pdrBoard{
                     emailFullInput.value = email;
                   }
                   showState("full");
-                  setMsg("No encontramos ese email. Completa tus datos para continuar.", true);
+                  setMsg("No encontramos ese email. Regístrate para continuar.", true);
                 } catch (_) {
-                  setMsg("No pudimos conectar. Intenta de nuevo.", true);
+                  setMsg("No pudimos conectar. Intenta de nuevo en 10 segundos.", true);
                 } finally {
                   setLoading(document.getElementById("leadEmailBtn"), false);
                 }
@@ -2015,14 +2015,14 @@ a.card.trustTile .pdrBoard{
                     phone,
                     hp: document.getElementById("website")?.value || ""
                   };
-                  const resp = await fetch("api/lead.php", {
+                  const resp = await fetch("/api/lead.php", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify(payload)
                   });
                   const data = await resp.json();
                   if (!data || !data.ok) {
-                    setMsg("No pudimos guardar tus datos. Intenta de nuevo.", true);
+                    setMsg("No pudimos conectar. Intenta de nuevo en 10 segundos.", true);
                     return;
                   }
                   saveAuth(email, {
@@ -2037,7 +2037,7 @@ a.card.trustTile .pdrBoard{
                   setMsg("✅ Guardado. Bajando al test…", false);
                   scrollToTest();
                 } catch (_) {
-                  setMsg("No pudimos conectar. Intenta de nuevo.", true);
+                  setMsg("No pudimos conectar. Intenta de nuevo en 10 segundos.", true);
                 } finally {
                   setLoading(document.getElementById("leadFullBtn"), false);
                 }
@@ -2792,7 +2792,7 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
     async function postLead(data){
       const body = { ...data, hp: document.getElementById("website")?.value || "" };
       if(UTM_QUERY){ body.utm = UTM_QUERY; }
-      const resp = await fetch("api/lead.php", {
+      const resp = await fetch("/api/lead.php", {
         method: "POST",
         headers: {"Content-Type":"application/json"},
         body: JSON.stringify(body)
@@ -2849,7 +2849,7 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
       try{
         result = await postLead(data);
       }catch(_){
-        result = {ok:false, message:"No se pudo guardar"};
+        result = {ok:false, message:"No pudimos conectar. Intenta de nuevo en 10 segundos."};
       }
 
       if(!result || !result.ok){

--- a/landing_venta.html
+++ b/landing_venta.html
@@ -1953,7 +1953,7 @@ a.card.trustTile .pdrBoard{
                 setMsg("", false);
                 setLoading(document.getElementById("leadEmailBtn"), true);
                 try {
-                  const resp = await fetch("api/lead.php", {
+                  const resp = await fetch("/api/lead.php", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({
@@ -1964,7 +1964,7 @@ a.card.trustTile .pdrBoard{
                   });
                   const data = await resp.json();
                   if (!data || !data.ok) {
-                    setMsg("No pudimos validar el email. Intenta de nuevo.", true);
+                    setMsg("No pudimos conectar. Intenta de nuevo en 10 segundos.", true);
                     return;
                   }
                   if (data.exists) {
@@ -1978,9 +1978,9 @@ a.card.trustTile .pdrBoard{
                     emailFullInput.value = email;
                   }
                   showState("full");
-                  setMsg("No encontramos ese email. Completa tus datos para continuar.", true);
+                  setMsg("No encontramos ese email. Regístrate para continuar.", true);
                 } catch (_) {
-                  setMsg("No pudimos conectar. Intenta de nuevo.", true);
+                  setMsg("No pudimos conectar. Intenta de nuevo en 10 segundos.", true);
                 } finally {
                   setLoading(document.getElementById("leadEmailBtn"), false);
                 }
@@ -2015,14 +2015,14 @@ a.card.trustTile .pdrBoard{
                     phone,
                     hp: document.getElementById("website")?.value || ""
                   };
-                  const resp = await fetch("api/lead.php", {
+                  const resp = await fetch("/api/lead.php", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify(payload)
                   });
                   const data = await resp.json();
                   if (!data || !data.ok) {
-                    setMsg("No pudimos guardar tus datos. Intenta de nuevo.", true);
+                    setMsg("No pudimos conectar. Intenta de nuevo en 10 segundos.", true);
                     return;
                   }
                   saveAuth(email, {
@@ -2037,7 +2037,7 @@ a.card.trustTile .pdrBoard{
                   setMsg("✅ Guardado. Bajando al test…", false);
                   scrollToTest();
                 } catch (_) {
-                  setMsg("No pudimos conectar. Intenta de nuevo.", true);
+                  setMsg("No pudimos conectar. Intenta de nuevo en 10 segundos.", true);
                 } finally {
                   setLoading(document.getElementById("leadFullBtn"), false);
                 }
@@ -2792,7 +2792,7 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
     async function postLead(data){
       const body = { ...data, hp: document.getElementById("website")?.value || "" };
       if(UTM_QUERY){ body.utm = UTM_QUERY; }
-      const resp = await fetch("api/lead.php", {
+      const resp = await fetch("/api/lead.php", {
         method: "POST",
         headers: {"Content-Type":"application/json"},
         body: JSON.stringify(body)
@@ -2849,7 +2849,7 @@ Si quieres emprender con una <strong>compañía global</strong> y construir una 
       try{
         result = await postLead(data);
       }catch(_){
-        result = {ok:false, message:"No se pudo guardar"};
+        result = {ok:false, message:"No pudimos conectar. Intenta de nuevo en 10 segundos."};
       }
 
       if(!result || !result.ok){


### PR DESCRIPTION
### Motivation
- Fix recurring "No pudimos conectar" failures by ensuring the lead endpoint always returns valid JSON and proper HTTP status codes.
- Prevent lead loss and duplication by stabilizing CSV storage, using file locks and deterministic email deduping.
- Improve UX by switching frontend requests to an absolute API path and providing clearer retry/registration messages.

### Description
- In `api/lead.php` disabled `display_errors`, added `respond_error()` helper, normalized request parsing to support `GET`/`POST`, and implemented `action=ping` for quick health checks.
- Use `__DIR__ . '/../data/leads.csv'` for storage, create the CSV with headers when missing, and protect reads/writes with `flock()` while returning explicit error codes like `READ_FAIL` and `WRITE_FAIL` on failure.
- Normalize emails with `trim+lowercase` for dedupe, implement `action=check` to return `{ok:true, exists:true/false}` and `action=upsert` to return `{ok:true, status:"exists"}` or `{ok:true, status:"created"}` without duplicating rows.
- Updated `index.html` and `landing_venta.html` to call the absolute endpoint `/api/lead.php` and changed client messages to show a 10s retry recommendation and the registration prompt `Regístrate para continuar.`

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739fde27448325b8c2816658b206ff)